### PR TITLE
LPS-53323 Permission propagation to message boards not working

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -31,9 +32,14 @@ import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.model.Role;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.PermissionPropagator;
+import com.liferay.portal.service.PortletLocalServiceUtil;
+import com.liferay.portal.service.RoleLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
 import com.liferay.portal.struts.PortletAction;
@@ -411,9 +417,13 @@ public class EditMessageAction extends PortletAction {
 					CaptchaUtil.check(actionRequest);
 				}
 
+				String propagateFrom;
+
 				if (threadId <= 0) {
 
 					// Post new thread
+
+					propagateFrom = "com.liferay.portlet.messageboards";
 
 					message = MBMessageServiceUtil.addMessage(
 						groupId, categoryId, subject, body,
@@ -429,10 +439,35 @@ public class EditMessageAction extends PortletAction {
 
 					// Post reply
 
+					propagateFrom = MBMessage.class.getName();
+
 					message = MBMessageServiceUtil.addMessage(
 						parentMessageId, subject, body,
 						mbSettings.getMessageFormat(), inputStreamOVPs,
 						anonymous, priority, allowPingbacks, serviceContext);
+				}
+
+				if (PropsValues.PERMISSIONS_PROPAGATION_ENABLED) {
+					List<Role> roles = RoleLocalServiceUtil.getRoles(
+						themeDisplay.getCompanyId());
+
+					long[] roleIds = {};
+
+					for (Role roleId : roles) {
+						roleIds = ArrayUtil.append(roleIds, roleId.getRoleId());
+					}
+
+					Portlet portlet = PortletLocalServiceUtil.getPortletById(
+						themeDisplay.getCompanyId(), themeDisplay.getPpid());
+
+					PermissionPropagator permissionPropagator =
+						portlet.getPermissionPropagatorInstance();
+
+					if (permissionPropagator != null) {
+						permissionPropagator.propagateRolePermissions(
+							actionRequest, propagateFrom,
+							String.valueOf(message.getMessageId()), roleIds);
+					}
 				}
 			}
 			else {

--- a/portal-impl/src/com/liferay/portlet/messageboards/security/permission/MBPermissionPropagatorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/security/permission/MBPermissionPropagatorImpl.java
@@ -51,7 +51,6 @@ public class MBPermissionPropagatorImpl extends BasePermissionPropagator {
 		}
 		else if (className.equals(MBMessage.class.getName())) {
 			long messageId = GetterUtil.getLong(primKey);
-
 			MBMessage message = MBMessageLocalServiceUtil.getMessage(messageId);
 
 			if (message.isRoot()) {
@@ -59,10 +58,25 @@ public class MBPermissionPropagatorImpl extends BasePermissionPropagator {
 					actionRequest, className, messageId, message.getThreadId(),
 					roleIds);
 			}
+			else {
+				propagateMessageRolePermissions(
+					actionRequest, className, message.getRootMessageId(),
+					messageId, roleIds);
+			}
 		}
 		else if (className.equals("com.liferay.portlet.messageboards")) {
-			propagateMBRolePermissions(
-				actionRequest, className, primKey, roleIds);
+			MBMessage message = MBMessageLocalServiceUtil.fetchMBMessage(
+				GetterUtil.getLong(primKey));
+
+			if (message != null) {
+				propagateMBRolePermissions(
+					actionRequest, className, message.getGroupId(), roleIds,
+					message.getMessageId());
+			}
+			else {
+				propagateMBRolePermissions(
+					actionRequest, className, primKey, roleIds);
+			}
 		}
 	}
 
@@ -159,6 +173,15 @@ public class MBPermissionPropagatorImpl extends BasePermissionPropagator {
 				}
 			}
 		}
+	}
+
+	protected void propagateMBRolePermissions(
+			ActionRequest actionRequest, String className, long primaryKey,
+			long[] roleIds, long messageId)
+		throws PortalException {
+
+		propagateMessageRolePermissions(
+			actionRequest, className, primaryKey, messageId, roleIds);
 	}
 
 	protected void propagateMBRolePermissions(

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_permissions.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_permissions.jsp
@@ -340,6 +340,20 @@ definePermissionsURL.setRefererPlid(plid);
 					guestUnsupportedActions.add(ActionKeys.VIEW);
 				}
 
+				// LPS-53323
+
+				boolean forceDisable = false;
+
+				if (PropsValues.PERMISSIONS_PROPAGATION_ENABLED && selResource.equals(MBMessage.class.getName())) {
+					MBMessage message = MBMessageLocalServiceUtil.fetchMBMessage(GetterUtil.getLong(resourcePrimKey));
+
+					if (message != null) {
+						if (!message.isRoot()) {
+							forceDisable = true;
+						}
+					}
+				}
+
 				for (String action : actions) {
 					boolean checked = false;
 					boolean disabled = false;
@@ -359,11 +373,15 @@ definePermissionsURL.setRefererPlid(plid);
 						preselectedMsg = "x-is-allowed-to-do-action-x-in-all-items-of-type-x-in-this-portal-instance";
 					}
 
-					if (name.equals(RoleConstants.GUEST) && guestUnsupportedActions.contains(action)) {
+					if (forceDisable) {
 						disabled = true;
 					}
 
-					if (action.equals(ActionKeys.ACCESS_IN_CONTROL_PANEL)) {
+					else if (name.equals(RoleConstants.GUEST) && guestUnsupportedActions.contains(action)) {
+						disabled = true;
+					}
+
+					else if (action.equals(ActionKeys.ACCESS_IN_CONTROL_PANEL)) {
 						disabled = true;
 					}
 				%>


### PR DESCRIPTION
Issue: Client is experiencing issue of LPS-34075. This fix has not yet been backported to 6.1 EE GA2, though it is listed as an affected version. Worth noting, the functionality does not work in 6.1 EE GA3 as well. This is highlighted in the steps 6 onwards.
Steps to replicate:
Add following property to 6.1 EE GA2 bundle and start the server: permissions.propagation.enabled=true
Add Message Boards Portlet to front page and select Permissions in the Portlet
Check User View permission
Post new thread
Click Permissions on thread
Expected Result: User View permissions would be checked and users would be able to view the thread without having to change User View permissions on every single thread.
Actual Result: Thread does not inherit the User View permission and a user with proper access would have to change the thread in order for users to view the thread.
6. Add following portal property to 6.1 EE GA3 and start Liferay: permissions.propagation.enabled=true
7. Add Message Boards Portlet to front page
8. Check User View permission
9. Post new thread
10. Click Permissions on thread. Note that permissions did not propagate
11. In the Message Boards Portlet select Permissions and hit Save
12. Click Permissions on the thread. Permissions have now propagated to the Thread
Expected Result: Permissions would have propagated upon creation
Actual Result: Permissions only propagated to existing threads when updated.
Tested in 6.1.x and Master
Reproduced in 6.1.x and Master