### PR TITLE
LPS-56148 Make URLs consistent. It seems that the tabs1 and the nodeName are not required.

### DIFF
--- a/modules/apps/asset/asset-publisher-test/snapshot.properties
+++ b/modules/apps/asset/asset-publisher-test/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=a1a2b946fddc6ca19ba1a870c8f63b991b14b4a9
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.asset.publisher.test/1.0.0-SNAPSHOT/com.liferay.asset.publisher.test-1.0.0-20150605.045136-5.jar
+module.snapshot.git.hash=99c40be104043c481e15305fdea740d7ea0dc074
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.asset.publisher.test/1.0.0-SNAPSHOT/com.liferay.asset.publisher.test-1.0.0-20150609.184827-6.jar
 			

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/snapshot.properties
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=8fe6b79277275ff61b4a972cbbfb5a557b9992c7
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.dynamic.data.lists.web/1.0.0-SNAPSHOT/com.liferay.dynamic.data.lists.web-1.0.0-20150605.045417-5.jar
+module.snapshot.git.hash=c43bb30f1f0980c56902abd3110a512e97471476
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.dynamic.data.lists.web/1.0.0-SNAPSHOT/com.liferay.dynamic.data.lists.web-1.0.0-20150609.184840-6.jar
 			

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/snapshot.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/snapshot.properties
@@ -1,0 +1,4 @@
+
+module.snapshot.git.hash=506c6eb84454a0ac3e83d41334dec025e80d684d
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.dynamic.data.mapping.test/1.0.0-SNAPSHOT/com.liferay.dynamic.data.mapping.test-1.0.0-20150609.184848-1.jar
+			

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/snapshot.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=0bf83a9353fad194f130e07d9d5be151d179b7f3
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.dynamic.data.mapping.web/1.0.0-SNAPSHOT/com.liferay.dynamic.data.mapping.web-1.0.0-20150605.213429-7.jar
+module.snapshot.git.hash=c43bb30f1f0980c56902abd3110a512e97471476
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.dynamic.data.mapping.web/1.0.0-SNAPSHOT/com.liferay.dynamic.data.mapping.web-1.0.0-20150609.184856-8.jar
 			

--- a/modules/apps/iframe/iframe-web/snapshot.properties
+++ b/modules/apps/iframe/iframe-web/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=cd0c0998bf8b0e4e84f2032d61a1e5c27a02cc78
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.iframe.web/1.0.0-SNAPSHOT/com.liferay.iframe.web-1.0.0-20150605.045512-5.jar
+module.snapshot.git.hash=8cfeb44c043d6d5373023af1376a6e8747989bf3
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.iframe.web/1.0.0-SNAPSHOT/com.liferay.iframe.web-1.0.0-20150609.184907-6.jar
 			

--- a/modules/apps/lar/lar-test/snapshot.properties
+++ b/modules/apps/lar/lar-test/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=5603d20c157314010b2b37b59af1d3d625a8c593
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.lar.test/1.0.0-SNAPSHOT/com.liferay.lar.test-1.0.0-20150605.045641-1.jar
+module.snapshot.git.hash=99c40be104043c481e15305fdea740d7ea0dc074
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.lar.test/1.0.0-SNAPSHOT/com.liferay.lar.test-1.0.0-20150609.184922-2.jar
 			

--- a/modules/apps/site/site-admin-web/snapshot.properties
+++ b/modules/apps/site/site-admin-web/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=6f2f8f1c9a9657dbbfccecdf6559efe013a1da7b
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.site.admin.web/1.0.0-SNAPSHOT/com.liferay.site.admin.web-1.0.0-20150605.045942-5.jar
+module.snapshot.git.hash=99c40be104043c481e15305fdea740d7ea0dc074
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.site.admin.web/1.0.0-SNAPSHOT/com.liferay.site.admin.web-1.0.0-20150609.184931-6.jar
 			

--- a/modules/apps/wiki/wiki-web/docroot/html/portlet/wiki/view_page_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/docroot/html/portlet/wiki/view_page_attachments.jsp
@@ -90,7 +90,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "attachm
 			<c:if test="<%= TrashUtil.isTrashEnabled(scopeGroupId) && (deletedAttachmentsCount > 0) %>">
 				<portlet:renderURL var="viewTrashAttachmentsURL">
 					<portlet:param name="struts_action" value="/wiki/view_page_attachments" />
-					<portlet:param name="tabs1" value="attachments" />
 					<portlet:param name="redirect" value="<%= currentURL %>" />
 					<portlet:param name="nodeId" value="<%= String.valueOf(node.getNodeId()) %>" />
 					<portlet:param name="title" value="<%= wikiPage.getTitle() %>" />
@@ -140,7 +139,6 @@ PortletURL iteratorURL = renderResponse.createRenderURL();
 iteratorURL.setParameter("struts_action", "/wiki/view_page_attachments");
 iteratorURL.setParameter("redirect", currentURL);
 iteratorURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
-iteratorURL.setParameter("nodeName", node.getName());
 iteratorURL.setParameter("title", wikiPage.getTitle());
 iteratorURL.setParameter("viewTrashAttachments", String.valueOf(viewTrashAttachments));
 %>

--- a/modules/apps/wiki/wiki-web/docroot/html/portlet/wiki/view_page_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/docroot/html/portlet/wiki/view_page_attachments.jsp
@@ -140,6 +140,8 @@ PortletURL iteratorURL = renderResponse.createRenderURL();
 iteratorURL.setParameter("struts_action", "/wiki/view_page_attachments");
 iteratorURL.setParameter("redirect", currentURL);
 iteratorURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
+iteratorURL.setParameter("nodeName", node.getName());
+iteratorURL.setParameter("title", wikiPage.getTitle());
 iteratorURL.setParameter("viewTrashAttachments", String.valueOf(viewTrashAttachments));
 %>
 

--- a/modules/portal/portal-search-elasticsearch/snapshot.properties
+++ b/modules/portal/portal-search-elasticsearch/snapshot.properties
@@ -1,4 +1,4 @@
 
-module.snapshot.git.hash=c6ba48cbfe7c515c47352d7a6f6d2c74eb7a0ccb
-module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.portal.search.elasticsearch/1.0.0-SNAPSHOT/com.liferay.portal.search.elasticsearch-1.0.0-20150605.172624-8.jar
+module.snapshot.git.hash=6ecefe8272d22b424b89a5ef1f7968275ab3569c
+module.snapshot.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/com.liferay.portal.search.elasticsearch/1.0.0-SNAPSHOT/com.liferay.portal.search.elasticsearch-1.0.0-20150609.184749-9.jar
 			


### PR DESCRIPTION
Hey @BryanEngler @jonathanmccann

Can you please review my changes?

It seems that the tabs1 is not necessary (since the view_page_attachments it's already setting attachments as the value)
Same happens for nodeName since nodeId should be enough.

If it looks good please fwd it to Brian

Thanks!