### PR TITLE
LPS-57318

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/cal/RecurrenceSerializer.java
+++ b/portal-service/src/com/liferay/portal/kernel/cal/RecurrenceSerializer.java
@@ -52,7 +52,7 @@ public class RecurrenceSerializer {
 			dayOfWeek = StringPool.QUESTION;
 		}
 		else if (frequency == Recurrence.DAILY) {
-			dayOfMonth += StringPool.FORWARD_SLASH + interval;
+			dayOfMonth = 1 + StringPool.FORWARD_SLASH + interval;
 			month = StringPool.STAR;
 			dayOfWeek = StringPool.QUESTION;
 			year = StringPool.STAR;


### PR DESCRIPTION
When we create the CRON text in the past, it would set the 'recurrence' date to be on the date you set. 

For instance, if you set it on the 30th, to reoccur daily - it would set the cron text to 30/1. (Reoccur on the 30th of each month, daily). So certain months it would run from the 30th, then the 31st, then the following month's 30th.. and so on - but not "daily" as described. 