### PR TITLE
LPS-57484

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.model.Image;
 import com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil;
@@ -105,6 +106,14 @@ public class BlogsEntryStagedModelDataHandler
 	@Override
 	public String getDisplayName(BlogsEntry entry) {
 		return entry.getTitle();
+	}
+
+	@Override
+	public int[] getExportableStatuses() {
+		return new int[] {
+			WorkflowConstants.STATUS_APPROVED,
+			WorkflowConstants.STATUS_SCHEDULED
+		};
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/blogs/service/permission/BlogsEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/permission/BlogsEntryPermission.java
@@ -73,9 +73,10 @@ public class BlogsEntryPermission implements BaseModelPermissionChecker {
 			return hasPermission.booleanValue();
 		}
 
-		if (entry.isDraft() || entry.isScheduled()) {
-			if (actionId.equals(ActionKeys.VIEW) &&
-				!contains(permissionChecker, entry, ActionKeys.UPDATE)) {
+		if (entry.isDraft() ||
+			(entry.isScheduled() && !permissionChecker.isSignedIn())) {
+				if (actionId.equals(ActionKeys.VIEW) &&
+					!contains(permissionChecker, entry, ActionKeys.UPDATE)) {
 
 				return false;
 			}


### PR DESCRIPTION
On the live site, we need to change the permissions so they admins can view the scheduled content; even though it won't be viewable to the regular users. 

Currently, if it's in the scheduled state, and on the live site, they will not have UPDATE permission, by design, automatically returning "false" for view permission. 

Web content doesn't work this way for scheduled content on the live site, and LPS-41902 was reverted in JournalArticlePermssion.java. 

If I remove LPS-41902, it becomes reproducible again. I wasn't sure if there was a better way to check for the unique permissions case; of scheduled blogs, and remote staging. 

https://github.com/sergiogonzalez/liferay-portal/pull/2482