### PR TITLE
LPS-68104 Group By ID so only unique entries are returned

### DIFF
--- a/modules/apps/web-experience/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/web-experience/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -225,6 +225,8 @@
 				([$FOLDER_ID$]) AND
 				([$OWNER_USER_ID$] [$OWNER_USER_ID_AND_OR_CONNECTOR$] [$STATUS$]) AND
 				(tempJournalArticle.id_ IS NULL)
+			GROUP BY
+				JournalArticle.id_
 			ORDER BY
 				JournalArticle.id_ ASC
 		]]>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-68104

Cannot use DISTINCT since clob datatypes are being returned, and some databases will fail when comparing them.