### PR TITLE
[TS] LPS-80931 - DateRangeTermFilter

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/filter/DateRangeTermFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/filter/DateRangeTermFilterTranslatorImpl.java
@@ -15,10 +15,8 @@
 package com.liferay.portal.search.elasticsearch6.internal.filter;
 
 import com.liferay.portal.kernel.search.filter.DateRangeTermFilter;
-import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 
-import java.text.Format;
-import java.text.ParseException;
+import java.util.TimeZone;
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -38,24 +36,16 @@ public class DateRangeTermFilterTranslatorImpl
 		RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(
 			dateRangeTermFilter.getField());
 
-		Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(
-			dateRangeTermFilter.getDateFormat(),
-			dateRangeTermFilter.getTimeZone());
+		rangeQueryBuilder.format(dateRangeTermFilter.getDateFormat());
+		rangeQueryBuilder.from(dateRangeTermFilter.getLowerBound());
+		rangeQueryBuilder.includeLower(dateRangeTermFilter.isIncludesLower());
+		rangeQueryBuilder.includeUpper(dateRangeTermFilter.isIncludesUpper());
 
-		try {
-			rangeQueryBuilder.from(
-				format.parseObject(dateRangeTermFilter.getLowerBound()));
-			rangeQueryBuilder.includeLower(
-				dateRangeTermFilter.isIncludesLower());
-			rangeQueryBuilder.includeUpper(
-				dateRangeTermFilter.isIncludesUpper());
-			rangeQueryBuilder.to(
-				format.parseObject(dateRangeTermFilter.getUpperBound()));
-		}
-		catch (ParseException pe) {
-			throw new IllegalArgumentException(
-				"Invalid date range " + dateRangeTermFilter, pe);
-		}
+		TimeZone timeZone = dateRangeTermFilter.getTimeZone();
+
+		rangeQueryBuilder.timeZone(timeZone.getID());
+
+		rangeQueryBuilder.to(dateRangeTermFilter.getUpperBound());
 
 		return rangeQueryBuilder;
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/filter/ElasticsearchDateRangeTermFilterTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/filter/ElasticsearchDateRangeTermFilterTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.filter;
+
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.LiferayIndexCreator;
+import com.liferay.portal.search.elasticsearch6.internal.pagination.ElasticsearchPermissionFilteredPaginationTest;
+import com.liferay.portal.search.test.util.filter.BaseDateRangeTermFilterTestCase;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Eric Yan
+ */
+public class ElasticsearchDateRangeTermFilterTest
+	extends BaseDateRangeTermFilterTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchPermissionFilteredPaginationTest.class.
+				getSimpleName());
+
+		return new ElasticsearchIndexingFixture(
+			elasticsearchFixture, BaseIndexingTestCase.COMPANY_ID,
+			new LiferayIndexCreator(elasticsearchFixture));
+	}
+
+}

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/filter/DateRangeTermFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/filter/DateRangeTermFilterTranslatorImpl.java
@@ -15,12 +15,25 @@
 package com.liferay.portal.search.solr.internal.filter;
 
 import com.liferay.portal.kernel.search.filter.DateRangeTermFilter;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.search.solr.filter.DateRangeTermFilterTranslator;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.TimeZone;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Michael C. Han
@@ -31,13 +44,99 @@ public class DateRangeTermFilterTranslatorImpl
 
 	@Override
 	public Query translate(DateRangeTermFilter dateRangeTermFilter) {
+		String multiDateFormatPattern = dateRangeTermFilter.getDateFormat();
+		TimeZone timeZone = dateRangeTermFilter.getTimeZone();
+
+		if ((multiDateFormatPattern == null) || (timeZone == null)) {
+			throw new IllegalArgumentException(
+				"Date format and/or timezone is null " + dateRangeTermFilter);
+		}
+
+		String lowerBound = dateRangeTermFilter.getLowerBound();
+		String upperBound = dateRangeTermFilter.getUpperBound();
+
+		if (!_dateFormatPattern.equals(multiDateFormatPattern) ||
+			!_TIME_ZONE_ID.equals(timeZone.getID())) {
+
+			try {
+				String[] dateFormats = StringUtil.split(
+					multiDateFormatPattern, "||");
+
+				if (lowerBound != null) {
+					ZonedDateTime lowerBoundZonedDateTime = parseFormattedDate(
+						lowerBound, dateFormats, timeZone);
+
+					lowerBound = formatDate(lowerBoundZonedDateTime);
+				}
+
+				if (upperBound != null) {
+					ZonedDateTime upperBoundZonedDateTime = parseFormattedDate(
+						upperBound, dateFormats, timeZone);
+
+					upperBound = formatDate(upperBoundZonedDateTime);
+				}
+			}
+			catch (IllegalArgumentException iae) {
+				throw new IllegalArgumentException(
+					"Invalid date format " + dateRangeTermFilter, iae);
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException(
+					"Invalid date range " + dateRangeTermFilter, e);
+			}
+		}
+
 		TermRangeQuery termRangeQuery = TermRangeQuery.newStringRange(
-			dateRangeTermFilter.getField(), dateRangeTermFilter.getLowerBound(),
-			dateRangeTermFilter.getUpperBound(),
+			dateRangeTermFilter.getField(), lowerBound, upperBound,
 			dateRangeTermFilter.isIncludesLower(),
 			dateRangeTermFilter.isIncludesUpper());
 
 		return termRangeQuery;
 	}
+
+	@Activate
+	protected void activate() {
+		_dateFormatPattern = props.get(PropsKeys.INDEX_DATE_FORMAT_PATTERN);
+	}
+
+	protected String formatDate(ZonedDateTime zonedDateTime) {
+		zonedDateTime = zonedDateTime.withZoneSameInstant(
+			ZoneId.of(_TIME_ZONE_ID));
+
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(
+			_dateFormatPattern);
+
+		return zonedDateTime.format(dateTimeFormatter);
+	}
+
+	protected ZonedDateTime parseFormattedDate(
+		String dateString, String[] dateFormats, TimeZone timeZone) {
+
+		for (int i = 0; i < dateFormats.length; i++) {
+			try {
+				DateTimeFormatter dateTimeFormatter =
+					DateTimeFormatter.ofPattern(dateFormats[i]);
+
+				LocalDateTime localDateTime = LocalDateTime.parse(
+					dateString, dateTimeFormatter);
+
+				return localDateTime.atZone(ZoneId.of(timeZone.getID()));
+			}
+			catch (Exception e) {
+				continue;
+			}
+		}
+
+		return null;
+	}
+
+	@Reference
+	protected Props props;
+
+	private static final TimeZone _TIME_ZONE = TimeZoneUtil.getDefault();
+
+	private static final String _TIME_ZONE_ID = _TIME_ZONE.getID();
+
+	private String _dateFormatPattern;
 
 }

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/filter/SolrDateRangeTermFilterTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/filter/SolrDateRangeTermFilterTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr.internal.filter;
+
+import com.liferay.portal.kernel.search.filter.DateRangeTermFilter;
+import com.liferay.portal.kernel.search.filter.FilterVisitor;
+import com.liferay.portal.search.solr.internal.SolrIndexingFixture;
+import com.liferay.portal.search.test.util.filter.BaseDateRangeTermFilterTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+import java.time.ZonedDateTime;
+
+import java.util.TimeZone;
+
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+/**
+ * @author Eric Yan
+ */
+public class SolrDateRangeTermFilterTest
+	extends BaseDateRangeTermFilterTestCase {
+
+	@Override
+	protected DateRangeTermFilter createDateRangeTermFilter(
+		String fieldName, boolean includesLower, boolean includesUpper,
+		ZonedDateTime lowerBoundZonedDateTime,
+		ZonedDateTime upperBoundZonedDateTime, String dateFormatPattern,
+		TimeZone timeZone) {
+
+		DateRangeTermFilter dateRangeTermFilter =
+			super.createDateRangeTermFilter(
+				fieldName, includesLower, includesUpper,
+				lowerBoundZonedDateTime, upperBoundZonedDateTime,
+				dateFormatPattern, timeZone);
+
+		return stubDateRangeTermFilter(dateRangeTermFilter);
+	}
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return new SolrIndexingFixture();
+	}
+
+	protected DateRangeTermFilter stubDateRangeTermFilter(
+		DateRangeTermFilter dateRangeTermFilter) {
+
+		dateRangeTermFilter = Mockito.spy(dateRangeTermFilter);
+
+		DateRangeTermFilterTranslatorImpl dateRangeTermFilterTranslator =
+			new DateRangeTermFilterTranslatorImpl();
+
+		dateRangeTermFilterTranslator.props = props;
+
+		dateRangeTermFilterTranslator.activate();
+
+		Mockito.doReturn(
+			dateRangeTermFilterTranslator.translate(dateRangeTermFilter)
+		).when(
+			dateRangeTermFilter
+		).accept(
+			Matchers.any(FilterVisitor.class)
+		);
+
+		return dateRangeTermFilter;
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/BaseDateRangeTermFilterTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/BaseDateRangeTermFilterTestCase.java
@@ -1,0 +1,588 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.filter;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.DateRangeTermFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Eric Yan
+ */
+public abstract class BaseDateRangeTermFilterTestCase
+	extends BaseIndexingTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		mockProps();
+	}
+
+	@Test
+	public void testBeforeLowerBound() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(1);
+
+		ZonedDateTime upperBoundZonedDateTime = null;
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testBeforeRange() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(1);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(2);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testBeforeUpperBound() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = null;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(1);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testCustomDateFormat() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(-1);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(1);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, "MMddyyyyHHmmss", DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testCustomTimeZone() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusHours(1);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusHours(3);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+
+		TimeZone timeZone = TimeZone.getTimeZone(ZoneId.of("Etc/GMT-2"));
+
+		dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, timeZone);
+
+		expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testLowerBoundExclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime;
+
+		ZonedDateTime upperBoundZonedDateTime = null;
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testLowerBoundInclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime;
+
+		ZonedDateTime upperBoundZonedDateTime = null;
+
+		boolean includeLower = true;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testPastLowerBound() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(-1);
+
+		ZonedDateTime upperBoundZonedDateTime = null;
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testPastRange() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(-2);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(-1);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testPastUpperBound() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = null;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(-1);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRange() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(-1);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(1);
+
+		addDocument(
+			DocumentCreationHelpers.singleDate(
+				FIELD, Date.from(zonedDateTime.toInstant())));
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRangeExclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime;
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRangeInclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime;
+
+		boolean includeLower = true;
+		boolean includeUpper = true;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRangeLowerBoundExclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(1);
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRangeLowerBoundInclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime.plusDays(1);
+
+		boolean includeLower = true;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRangeUpperBoundExclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(-1);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime;
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testRangeUpperBoundInclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = zonedDateTime.plusDays(-1);
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime;
+
+		boolean includeLower = false;
+		boolean includeUpper = true;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testUpperBoundExclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = null;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime;
+
+		boolean includeLower = false;
+		boolean includeUpper = false;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList();
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	@Test
+	public void testUpperBoundInclusive() throws Exception {
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(
+			LocalDateTime.of(2000, 11, 22, 0, 0, 0), ZoneId.systemDefault());
+
+		addDocument(FIELD, zonedDateTime);
+
+		ZonedDateTime lowerBoundZonedDateTime = null;
+		ZonedDateTime upperBoundZonedDateTime = zonedDateTime;
+
+		boolean includeLower = false;
+		boolean includeUpper = true;
+
+		DateRangeTermFilter dateRangeTermFilter = createDateRangeTermFilter(
+			FIELD, includeLower, includeUpper, lowerBoundZonedDateTime,
+			upperBoundZonedDateTime, DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
+
+		List<String> expectedValues = Arrays.asList("20001122000000");
+
+		assertSearch(dateRangeTermFilter, FIELD, expectedValues);
+	}
+
+	protected void addDocument(String fieldName, ZonedDateTime zonedDateTime)
+		throws Exception {
+
+		Date date = Date.from(zonedDateTime.toInstant());
+
+		addDocument(DocumentCreationHelpers.singleDate(fieldName, date));
+	}
+
+	protected void assertSearch(
+			Filter filter, String fieldName, List<String> expectedValues)
+		throws Exception {
+
+		IdempotentRetryAssert.retryAssert(
+			10, TimeUnit.SECONDS,
+			() -> doAssertSearch(filter, fieldName, expectedValues));
+	}
+
+	protected DateRangeTermFilter createDateRangeTermFilter(
+		String fieldName, boolean includesLower, boolean includesUpper,
+		ZonedDateTime lowerBoundZonedDateTime,
+		ZonedDateTime upperBoundZonedDateTime, String dateFormatPattern,
+		TimeZone timeZone) {
+
+		String formattedEndDate = null;
+		String formattedStartDate = null;
+
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(
+			dateFormatPattern);
+
+		if (upperBoundZonedDateTime != null) {
+			formattedEndDate = upperBoundZonedDateTime.format(
+				dateTimeFormatter);
+		}
+
+		if (lowerBoundZonedDateTime != null) {
+			formattedStartDate = lowerBoundZonedDateTime.format(
+				dateTimeFormatter);
+		}
+
+		DateRangeTermFilter dateRangeTermFilter = new DateRangeTermFilter(
+			fieldName, includesLower, includesUpper, formattedStartDate,
+			formattedEndDate);
+
+		dateRangeTermFilter.setDateFormat(dateFormatPattern);
+		dateRangeTermFilter.setTimeZone(timeZone);
+
+		return dateRangeTermFilter;
+	}
+
+	protected Void doAssertSearch(
+			Filter filter, String fieldName, List<String> expectedValues)
+		throws Exception {
+
+		SearchContext searchContext = createSearchContext();
+
+		Hits hits = search(
+			searchContext,
+			booleanQuery -> setPreBooleanFilter(filter, booleanQuery));
+
+		DocumentsAssert.assertValues(
+			(String)searchContext.getAttribute("queryString"), hits.getDocs(),
+			fieldName, expectedValues);
+
+		return null;
+	}
+
+	protected void mockProps() {
+		Mockito.when(
+			props.get(PropsKeys.INDEX_DATE_FORMAT_PATTERN)
+		).thenReturn(
+			DEFAULT_DATE_FORMAT
+		);
+
+		PropsUtil.setProps(props);
+	}
+
+	protected void setPreBooleanFilter(Filter filter, Query query) {
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		booleanFilter.add(filter, BooleanClauseOccur.MUST);
+
+		query.setPreBooleanFilter(booleanFilter);
+	}
+
+	protected static final String DEFAULT_DATE_FORMAT = "yyyyMMddHHmmss";
+
+	protected static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getDefault();
+
+	protected static final String FIELD = Field.EXPIRATION_DATE;
+
+	protected Props props = Mockito.mock(Props.class);
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentCreationHelpers.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentCreationHelpers.java
@@ -14,10 +14,18 @@
 
 package com.liferay.portal.search.test.util.indexing;
 
+import java.util.Date;
+
 /**
  * @author André de Oliveira
  */
 public class DocumentCreationHelpers {
+
+	public static DocumentCreationHelper singleDate(
+		String fieldName, Date value) {
+
+		return document -> document.addDate(fieldName, value);
+	}
 
 	public static DocumentCreationHelper singleGeoLocation(
 		String fieldName, double latitude, double longitude) {

--- a/portal-kernel/src/com/liferay/portal/kernel/search/filter/DateRangeTermFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/filter/DateRangeTermFilter.java
@@ -31,6 +31,11 @@ public class DateRangeTermFilter extends RangeTermFilter {
 		super(field, includesLower, includesUpper, startDate, endDate);
 	}
 
+	@Override
+	public <T> T accept(FilterVisitor<T> filterVisitor) {
+		return filterVisitor.visit(this);
+	}
+
 	public String getDateFormat() {
 		return _dateFormat;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/filter/DateRangeTermFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/filter/DateRangeTermFilter.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.search.filter;
 
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
 
@@ -72,7 +74,8 @@ public class DateRangeTermFilter extends RangeTermFilter {
 		return sb.toString();
 	}
 
-	private String _dateFormat = "yyyyMMddHHmmss";
+	private String _dateFormat = PropsUtil.get(
+		PropsKeys.INDEX_DATE_FORMAT_PATTERN);
 	private TimeZone _timeZone = TimeZoneUtil.getDefault();
 
 }


### PR DESCRIPTION
Hi @BryanEngler,

Can you help review this pr?
I figured it would be better if you could take a look, before sending it to Andre.

Thanks!

----
##  Background
The **DateRangeTermFilter** currently acts exactly the same as a RangeTermFilter. This is due to a missing override function: https://github.com/BryanEngler/liferay-portal/commit/fdb77552dcee2999dd2d3595797965fed2ff042f

The current logic appears to be incorrect/incomplete for both **Elasticsearch** and **Solr**.

## DateRangeTermFilter - Design
Looking at the design of the **DateRangeTermFilter**, it looks very similar to **Elasticsearch's Range Query**.

Especially since it contains the attributes: **dateFormat** and **timeZone**

**Reference:** https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-range-query.html#_date_format_in_range_queries

Solr uses UTC for it's dates

**Reference:** https://lucene.apache.org/solr/guide/6_6/working-with-dates.html

## Fix - Approach
The approach I took for this fix is to make the **DateRangeTermFilter** work similarly to **Elasticsearch's Range Query**.

**Elasticsearch**
For Elasticsearch, we could simply use it's API and set the proper values.
This is simple, since the design is similar to Elasticsearch's Range Query.

**Solr**
For Solr, the Date fields are actually stored as String.
This means that we have to make sure the dates used for our date range are formatted using the same **date format** as the one Liferay uses when storing **date fields** in Solr.
