### PR TITLE
[TS] LPS-77301 - Solr Only - Filtering search results by a tag containing spaces doesn't work

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/filter/TermFilterTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/filter/TermFilterTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.filter;
+
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.LiferayIndexCreator;
+import com.liferay.portal.search.test.util.filter.BaseTermFilterTestCase;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Eric Yan
+ */
+public class TermFilterTest extends BaseTermFilterTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
+			TermFilterTest.class.getSimpleName());
+
+		return new ElasticsearchIndexingFixture(
+			elasticsearchFixture, BaseIndexingTestCase.COMPANY_ID,
+			new LiferayIndexCreator(elasticsearchFixture));
+	}
+
+}

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/filter/TermFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/filter/TermFilterTranslatorImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.search.solr.filter.TermFilterTranslator;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.solr.client.solrj.util.ClientUtils;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -31,7 +32,9 @@ public class TermFilterTranslatorImpl implements TermFilterTranslator {
 
 	@Override
 	public Query translate(TermFilter termFilter) {
-		Term term = new Term(termFilter.getField(), termFilter.getValue());
+		Term term = new Term(
+			termFilter.getField(),
+			ClientUtils.escapeQueryChars(termFilter.getValue()));
 
 		TermQuery termQuery = new TermQuery(term);
 

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/filter/TermsFilterTranslatorImpl.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/filter/TermsFilterTranslatorImpl.java
@@ -24,6 +24,7 @@ import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.solr.client.solrj.util.ClientUtils;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -40,7 +41,7 @@ public class TermsFilterTranslatorImpl implements TermsFilterTranslator {
 		ArrayList<Term> terms = new ArrayList<>();
 
 		for (String value : termsFilter.getValues()) {
-			terms.add(new Term(field, value));
+			terms.add(new Term(field, ClientUtils.escapeQueryChars(value)));
 		}
 
 		TermsQuery termsQuery = new TermsQuery(terms);

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/filter/TermFilterTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/filter/TermFilterTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr.internal.filter;
+
+import com.liferay.portal.search.solr.internal.SolrIndexingFixture;
+import com.liferay.portal.search.test.util.filter.BaseTermFilterTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Eric Yan
+ */
+public class TermFilterTest extends BaseTermFilterTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return new SolrIndexingFixture();
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/BaseTermFilterTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/BaseTermFilterTestCase.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
-import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -35,71 +35,56 @@ import org.junit.Test;
 
 /**
  * @author André de Oliveira
+ * @author Eric Yan
  */
-public abstract class BaseTermsFilterTestCase extends BaseIndexingTestCase {
+public abstract class BaseTermFilterTestCase extends BaseIndexingTestCase {
 
 	@Test
 	public void testKeywordField() throws Exception {
 		String fieldName = Field.FOLDER_ID;
+		String value = "One";
 
-		addDocuments(
-			value -> DocumentCreationHelpers.singleKeyword(fieldName, value),
-			Arrays.asList("One", "Two", "Three"));
+		addDocument(DocumentCreationHelpers.singleKeyword(fieldName, value));
 
-		TermsFilter termsFilter = new TermsFilter(fieldName);
+		TermFilter termFilter = new TermFilter(fieldName, value);
 
-		termsFilter.addValues("Two", "Three");
-
-		assertSearch(termsFilter, fieldName, Arrays.asList("Two", "Three"));
+		assertSearch(termFilter, fieldName, Arrays.asList(value));
 	}
 
 	@Test
 	public void testLuceneSpecialCharacters() throws Exception {
 		String fieldName = Field.FOLDER_ID;
+		String value = "One\\+-!():^[]\"{}~*?|&/Two";
 
-		addDocuments(
-			value -> DocumentCreationHelpers.singleKeyword(fieldName, value),
-			Arrays.asList("One\\+-!():^[]\"{}~*?|&/Two", "Three"));
+		addDocument(DocumentCreationHelpers.singleKeyword(fieldName, value));
 
-		TermsFilter termsFilter = new TermsFilter(fieldName);
+		TermFilter termFilter = new TermFilter(fieldName, value);
 
-		termsFilter.addValues("One\\+-!():^[]\"{}~*?|&/Two", "Three");
-
-		assertSearch(
-			termsFilter, fieldName,
-			Arrays.asList("One\\+-!():^[]\"{}~*?|&/Two", "Three"));
+		assertSearch(termFilter, fieldName, Arrays.asList(value));
 	}
 
 	@Test
 	public void testSolrSpecialCharacters() throws Exception {
 		String fieldName = Field.FOLDER_ID;
+		String value = "One\\+-!():^[]\"{}~*?|&/; Two";
 
-		addDocuments(
-			value -> DocumentCreationHelpers.singleKeyword(fieldName, value),
-			Arrays.asList("One\\+-!():^[]\"{}~*?|&/; Two", "Three"));
+		addDocument(DocumentCreationHelpers.singleKeyword(fieldName, value));
 
-		TermsFilter termsFilter = new TermsFilter(fieldName);
+		TermFilter termFilter = new TermFilter(fieldName, value);
 
-		termsFilter.addValues("One\\+-!():^[]\"{}~*?|&/; Two", "Three");
-
-		assertSearch(
-			termsFilter, fieldName,
-			Arrays.asList("One\\+-!():^[]\"{}~*?|&/; Two", "Three"));
+		assertSearch(termFilter, fieldName, Arrays.asList(value));
 	}
 
 	@Test
 	public void testSpaces() throws Exception {
 		String fieldName = Field.FOLDER_ID;
+		String value = "One Two";
 
-		addDocuments(
-			value -> DocumentCreationHelpers.singleKeyword(fieldName, value),
-			Arrays.asList("One Two", "Three"));
+		addDocument(DocumentCreationHelpers.singleKeyword(fieldName, value));
 
-		TermsFilter termsFilter = new TermsFilter(fieldName);
+		TermFilter termFilter = new TermFilter(fieldName, value);
 
-		termsFilter.addValues("One Two", "Three");
-
-		assertSearch(termsFilter, fieldName, Arrays.asList("One Two", "Three"));
+		assertSearch(termFilter, fieldName, Arrays.asList(value));
 	}
 
 	protected void assertSearch(


### PR DESCRIPTION
Hi @BryanEngler,

This pr is for the Solr issue where spaces are not being escaped for the TermFilter and TermsFilter. This is an issue when filtering search results with a tag that contains spaces.

**Fix**
For this fix, we are using Solr's **ClientUtils::escapeQueryChars** method.
This is basically the same as Lucene's escape method, except it also includes:
- whitespaces
- semicolon

References:
- Lucene: [QueryParserBase.java#QueryParserBase.escape](http://grepcode.com/file/repo1.maven.org/maven2/org.apache.lucene/lucene-queryparser/5.2.1/org/apache/lucene/queryparser/classic/QueryParserBase.java#QueryParserBase.escape%28java.lang.String%29)
- Solr: [ClientUtils.java#ClientUtils.escapeQueryChars](http://grepcode.com/file/repo1.maven.org/maven2/org.apache.solr/solr-solrj/5.2.1/org/apache/solr/client/solrj/util/ClientUtils.java#ClientUtils.escapeQueryChars%28java.lang.String%29)

Please let me know if you have any questions.
Thanks!