### PR TITLE
LPS-88599 Bump zookeeper version for solr modules

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/build.gradle
+++ b/modules/apps/portal-search-solr/portal-search-solr/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	compileInclude group: "org.apache.lucene", name: "lucene-queryparser", version: "5.2.1"
 	compileInclude group: "org.apache.lucene", name: "lucene-suggest", version: "5.2.1"
 	compileInclude group: "org.apache.solr", name: "solr-solrj", version: "5.2.1"
-	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.7"
+	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.10"
 	compileInclude group: "org.codehaus.woodstox", name: "stax2-api", version: "3.1.4"
 	compileInclude group: "org.codehaus.woodstox", name: "woodstox-core-asl", version: "4.4.1"
 	compileInclude group: "org.noggit", name: "noggit", version: "0.6"

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/build.gradle
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 	compileInclude group: "org.apache.lucene", name: "lucene-queryparser", version: luceneVersion
 	compileInclude group: "org.apache.lucene", name: "lucene-suggest", version: luceneVersion
 	compileInclude group: "org.apache.solr", name: "solr-solrj", version: luceneVersion
-	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.7"
+	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.10"
 	compileInclude group: "org.codehaus.woodstox", name: "stax2-api", version: "3.1.4"
 	compileInclude group: "org.codehaus.woodstox", name: "woodstox-core-asl", version: "4.4.1"
 	compileInclude group: "org.noggit", name: "noggit", version: "0.6"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88599

Hey Bryan,

3.4.10 does not cause startup issues (no unresolved depenencies), SolrCloud works after the change:
```
2019-01-25 19:37:02.529 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:zookeeper.version=3.4.10-39d3a4f269333c922ed3db283be479f9deacaa0f, built on 03/23/2017 10:13 GMT
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:host.name=tibusz-3520
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.version=1.8.0_201
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.vendor=Oracle Corporation
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.home=/usr/lib/jvm/java-8-oracle/jre
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.class.path=/home/tibusz/liferay/bundles/master/tomcat-9.0.10/bin/bootstrap.jar:/home/tibusz/liferay/bundles/master/tomcat-9.0.10/bin/tomcat-juli.jar:/home/tibusz/git/liferay/ce/liferay-portal/lib/portal/aspectj-weaver.jar
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib
2019-01-25 19:37:02.530 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.io.tmpdir=/home/tibusz/liferay/bundles/master/tomcat-9.0.10/temp
2019-01-25 19:37:02.546 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:java.compiler=<NA>
2019-01-25 19:37:02.553 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:os.name=Linux
2019-01-25 19:37:02.553 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:os.arch=amd64
2019-01-25 19:37:02.553 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:os.version=4.4.0-141-generic
2019-01-25 19:37:02.556 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:user.name=tibusz
2019-01-25 19:37:02.556 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:user.home=/home/tibusz
2019-01-25 19:37:02.557 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:100] Client environment:user.dir=/home/tibusz/liferay/bundles/master/tomcat-9.0.10/bin
2019-01-25 19:37:02.558 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZooKeeper:438] Initiating client connection, connectString=localhost:9983 sessionTimeout=10000 watcher=org.apache.solr.common.cloud.SolrZkClient$1@380eb288
2019-01-25 19:37:02.651 INFO  [liferay/search_writer/SYSTEM_ENGINE-3-SendThread(localhost:9983)][ClientCnxn:1032] Opening socket connection to server localhost/127.0.0.1:9983. Will not attempt to authenticate using SASL (unknown error)
2019-01-25 19:37:02.654 INFO  [liferay/search_writer/SYSTEM_ENGINE-3-SendThread(localhost:9983)][ClientCnxn:876] Socket connection established to localhost/127.0.0.1:9983, initiating session
2019-01-25 19:37:02.683 INFO  [liferay/search_writer/SYSTEM_ENGINE-3-SendThread(localhost:9983)][ClientCnxn:1299] Session establishment complete on server localhost/127.0.0.1:9983, sessionid = 0x10000420e990007, negotiated timeout = 10000
2019-01-25 19:37:02.699 INFO  [zkConnectionManagerCallback-5-thread-1][ConnectionManager:119] zkClient has connected
2019-01-25 19:37:02.736 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZkStateReader:786] Updated live nodes from ZooKeeper... (0) -> (2)
2019-01-25 19:37:02.772 INFO  [liferay/search_writer/SYSTEM_ENGINE-3][ZkClientClusterStateProvider:158] Cluster at localhost:9983 ready
```

Please forward to Brian so I can proceed with the backports. Or ask him to merge to 7.1.x and 7.0.x too. :-)

Thanks,
Tibor