### PR TITLE
LPS-90078 Search Results widget "Pagination Delta" default setting ignores search.container.page.default.delta

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortletPreferencesImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortletPreferencesImpl.java
@@ -14,7 +14,10 @@
 
 package com.liferay.portal.search.web.internal.search.results.portlet;
 
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.search.web.internal.util.PortletPreferencesHelper;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.Optional;
 
@@ -37,7 +40,9 @@ public class SearchResultsPortletPreferencesImpl
 	public int getPaginationDelta() {
 		return _portletPreferencesHelper.getInteger(
 			SearchResultsPortletPreferences.PREFERENCE_KEY_PAGINATION_DELTA,
-			20);
+			GetterUtil.getInteger(
+				PropsUtil.get(PropsKeys.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA),
+				20));
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90078

Hey Bryan,

I'm re-sending my original fix as there are many places in `portal-search-web` where we use `PropsValues` directly. Unless there is a pattern to do it in a different way I think we can go with this.

Thanks!