### PR TITLE
[TS] LPS-94230 Search results are not visible when paginating on JBoss/Wildfly

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/PortletSharedRequestHelperImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/PortletSharedRequestHelperImpl.java
@@ -45,8 +45,8 @@ public class PortletSharedRequestHelperImpl
 
 	@Override
 	public String getCompleteURL(RenderRequest renderRequest) {
-		String urlString = _http.getCompleteURL(
-			getSharedRequest(renderRequest));
+		String urlString = _http.getCompleteOriginalURL(
+			portal.getHttpServletRequest(renderRequest));
 
 		return urlString;
 	}

--- a/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
@@ -984,6 +984,11 @@ public class TemplateContextHelper {
 		}
 
 		@Override
+		public String getCompleteOriginalURL(HttpServletRequest request) {
+			return _http.getCompleteOriginalURL(request);
+		}
+
+		@Override
 		public String getCompleteURL(HttpServletRequest request) {
 			return _http.getCompleteURL(request);
 		}

--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.InetAddressUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -449,6 +450,75 @@ public class HttpImpl implements Http {
 	@Deprecated
 	public HttpClient getClient(HostConfiguration hostConfiguration) {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getCompleteOriginalURL(HttpServletRequest request) {
+		boolean forwarded = false;
+
+		if (request.getAttribute(
+				JavaConstants.JAVAX_SERVLET_FORWARD_REQUEST_URI) != null) {
+
+			forwarded = true;
+		}
+
+		String requestURL = null;
+		String queryString = null;
+
+		if (forwarded) {
+			requestURL = PortalUtil.getAbsoluteURL(
+				request,
+				(String)request.getAttribute(
+					JavaConstants.JAVAX_SERVLET_FORWARD_REQUEST_URI));
+
+			queryString = (String)request.getAttribute(
+				JavaConstants.JAVAX_SERVLET_FORWARD_QUERY_STRING);
+		}
+		else {
+			requestURL = String.valueOf(request.getRequestURL());
+
+			queryString = request.getQueryString();
+		}
+
+		StringBuffer sb = new StringBuffer();
+
+		sb.append(requestURL);
+
+		if (queryString != null) {
+			sb.append(StringPool.QUESTION);
+			sb.append(queryString);
+		}
+
+		String proxyPath = PortalUtil.getPathProxy();
+
+		if (Validator.isNotNull(proxyPath)) {
+			int x =
+				sb.indexOf(Http.PROTOCOL_DELIMITER) +
+					Http.PROTOCOL_DELIMITER.length();
+
+			int y = sb.indexOf(StringPool.SLASH, x);
+
+			sb.insert(y, proxyPath);
+		}
+
+		String completeURL = sb.toString();
+
+		if (request.isRequestedSessionIdFromURL()) {
+			HttpSession session = request.getSession();
+
+			String sessionId = session.getId();
+
+			completeURL = PortalUtil.getURLWithSessionId(
+				completeURL, sessionId);
+		}
+
+		if (_log.isWarnEnabled()) {
+			if (completeURL.contains("?&")) {
+				_log.warn("Invalid url " + completeURL);
+			}
+		}
+
+		return completeURL;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Http.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Http.java
@@ -93,6 +93,8 @@ public interface Http {
 
 	public String fixPath(String path, boolean leading, boolean trailing);
 
+	public String getCompleteOriginalURL(HttpServletRequest request);
+
 	public String getCompleteURL(HttpServletRequest request);
 
 	public Cookie[] getCookies();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/HttpUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HttpUtil.java
@@ -100,6 +100,10 @@ public class HttpUtil {
 		return getHttp().fixPath(path, leading, trailing);
 	}
 
+	public static String getCompleteOriginalURL(HttpServletRequest request) {
+		return getHttp().getCompleteOriginalURL(request);
+	}
+
 	public static String getCompleteURL(HttpServletRequest request) {
 		return getHttp().getCompleteURL(request);
 	}


### PR DESCRIPTION
[LPS-94230](https://issues.liferay.com/browse/LPS-94230)

Hi Bryan,

I am sending this to you as [Tibor Lipusz suggested it](https://github.com/lipusz/liferay-portal/pull/263#issuecomment-484524344).

**Issue:**
Results disappear in Search Results portlet when switching between pages  on JBoss/WildFly (and probably Websphere too). The reason is that SearchContainer._iteratorURL doesn't contain the search keyword (q parameter).

**Technical Background:**
The issue originates from the **incorrect assumption** that PortalImpl.getOriginalServletRequest(HttpServletRequest) returns the "original request" carrying the URL, query string, etc. as it comes from the browser.

The request (in recent scenario a RenderRequest) we retrieve the original URL and query string from is wrapped multiple times and went through several RequestDispatchers. I found no info in [Servlet 3 specification](https://download.oracle.com/otn-pub/jcp/servlet-3.0-fr-eval-oth-JSpec/servlet-3_0-final-spec.pdf) what to expect from the current approach of unwrapping the "original request" (done by PortalImpl.getOriginalServletRequest(HttpServletRequest)). The specification, however, describes how to access the properties of the "original request" (facing the very first servlet) in case of forwarded/included requests.

> 9.3.1 Included Request Parameters
> 
> ...
> 
> The following request attributes must be set:
> 
> javax.servlet.include.request_uri
> javax.servlet.include.context_path
> javax.servlet.include.servlet_path
> javax.servlet.include.path_info
> javax.servlet.include.query_string
> 
> These attributes are accessible from the included servlet via the getAttribute method on the request object and their values must be equal to the request URI, context path, servlet path, path info, and query string of the included servlet, respectively. If the request is subsequently included, these attributes are replaced for that include.

> 9.4.2 Forwarded Request Parameters
> 
> ...
> 
> The following request attributes must be set:
> 
> javax.servlet.forward.request_uri
> javax.servlet.forward.context_path
> javax.servlet.forward.servlet_path
> javax.servlet.forward.path_info
> javax.servlet.forward.query_string
> 
> The values of these attributes must be equal to the return values of the HttpServletRequest methods getRequestURI, getContextPath, getServletPath, getPathInfo, getQueryString respectively, invoked on the request object passed to the first servlet object in the call chain that received the request from the client.
> These attributes are accessible from the forwarded servlet via the getAttribute method on the request object. Note that these attributes must always reflect the information in the original request even under the situation that multiple forwards and subsequent includes are called.

**How I understand the spec:** 
If the request was forwarded, then the properties (request URI, context path, servlet path, path_info, query_string) of the originally sent request are preserved by the javax.servlet.forward.* attributes. For included request we can call the getter methods directly on the request as they return the values belonging to the originally sent request. That is, we have to handle distinctively only the case of forwarded requests.

**Automated tests:**
I think this issue cannot be covered by automated tests. At least, I couldn't figure out how this application server specific request dispatching issue could be tested in connection with search or more generally via PortalUtil. Please let me know if you have an idea.

Thanks for reviewing,
Istvan