### PR TITLE
LPS-88817 portal-search-ranking-web: Update fetch parameters

### DIFF
--- a/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/edit_results_rankings.jsp
+++ b/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/edit_results_rankings.jsp
@@ -73,7 +73,6 @@ String[] aliases = StringUtil.split(ParamUtil.getString(request, "aliases"), Str
 
 <liferay-portlet:resourceURL id="/results_ranking/get_results" portletName="<%= ResultsRankingPortletKeys.RESULTS_RANKING %>" var="resultsRankingResourceURL">
 	<portlet:param name="resultsRankingUid" value="<%= resultsRankingUid %>" />
-	<portlet:param name="keywords" value="<%= keywords %>" />
 	<portlet:param name="companyId" value="<%= companyId %>" />
 	<portlet:param name="<%= Constants.CMD %>" value="getVisibleResults" />
 </liferay-portlet:resourceURL>
@@ -101,7 +100,6 @@ String[] aliases = StringUtil.split(ParamUtil.getString(request, "aliases"), Str
 				WORKFLOW_ACTION_SAVE_DRAFT: '<%= WorkflowConstants.ACTION_SAVE_DRAFT %>'
 			},
 			namespace: '<portlet:namespace />',
-			searchIndex: '',
 			spritemap: '<%= themeDisplay.getPathThemeImages() + "/lexicon/icons.svg" %>'
 		}
 	);

--- a/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/ThemeContext.es.js
+++ b/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/ThemeContext.es.js
@@ -5,7 +5,6 @@ export default React.createContext(
 		companyId: '',
 		constants: {},
 		namespace: '',
-		searchIndex: '',
 		spritemap: ''
 	}
 );

--- a/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/components/ResultsRankingForm.es.js
+++ b/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/components/ResultsRankingForm.es.js
@@ -328,17 +328,17 @@ class ResultsRankingForm extends Component {
 			}
 		);
 
+		const {companyId, namespace} = this.context;
+
 		const visibleIdList = this._getResultIdsVisible();
 
 		return fetchDocuments(
 			this.props.fetchDocumentsUrl,
 			{
-				companyId: this.context.companyId,
-				from: visibleIdList.length,
-				hidden: false,
-				keywords: this.props.searchTerm,
-				searchIndex: this.context.searchIndex,
-				size: DELTA
+				[`${namespace}companyId`]: companyId,
+				[`${namespace}from`]: visibleIdList.length,
+				[`${namespace}keywords`]: this.props.searchTerm,
+				[`${namespace}size`]: DELTA
 			}
 		).then(
 			({items, total}) => {
@@ -415,15 +415,15 @@ class ResultsRankingForm extends Component {
 
 		const {resultIdsHidden} = this.state;
 
+		const {companyId, namespace} = this.context;
+
 		return fetchDocuments(
 			this.props.fetchDocumentsHiddenUrl,
 			{
-				companyId: this.context.companyId,
-				from: resultIdsHidden.length,
-				hidden: true,
-				keywords: this.props.searchTerm,
-				searchIndex: this.context.searchIndex,
-				size: DELTA
+				[`${namespace}companyId`]: companyId,
+				[`${namespace}from`]: resultIdsHidden.length,
+				[`${namespace}keywords`]: this.props.searchTerm,
+				[`${namespace}size`]: DELTA
 			}
 		).then(
 			({items, total}) => {

--- a/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/components/add_result/index.es.js
+++ b/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/components/add_result/index.es.js
@@ -71,6 +71,8 @@ class AddResult extends Component {
 	_fetchSearchResults = () => {
 		const {addResultSearchTerm, page, selectedDelta} = this.state;
 
+		const {companyId, namespace} = this.context;
+
 		this.setState(
 			{
 				dataLoading: true,
@@ -81,12 +83,10 @@ class AddResult extends Component {
 		fetchDocuments(
 			this.props.fetchDocumentsUrl,
 			{
-				companyId: this.context.companyId,
-				from: (page * selectedDelta) - selectedDelta,
-				hidden: false,
-				keywords: addResultSearchTerm,
-				searchIndex: this.context.searchIndex,
-				size: selectedDelta
+				[`${namespace}companyId`]: companyId,
+				[`${namespace}from`]: (page * selectedDelta) - selectedDelta,
+				[`${namespace}keywords`]: addResultSearchTerm,
+				[`${namespace}size`]: selectedDelta
 			}
 		).then(
 			({items, total}) => {

--- a/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/utils/__mocks__/api.es.js
+++ b/modules/apps/portal-search/portal-search-ranking-web/src/main/resources/META-INF/resources/js/utils/__mocks__/api.es.js
@@ -1,4 +1,7 @@
-import {getMockResultsData} from 'test/mock-data.js';
+import {
+	FETCH_HIDDEN_DOCUMENTS_URL,
+	getMockResultsData
+} from 'test/mock-data.js';
 
 /**
  * Fetches documents.
@@ -10,14 +13,14 @@ export const fetchDocuments = jest.fn(
 		url,
 		config
 	) => {
-		const {from, hidden, keywords, size} = config;
+		const {from, keywords, size} = config;
 
 		const p = Promise.resolve(
 			getMockResultsData(
 				size,
 				from,
 				keywords,
-				hidden
+				url === FETCH_HIDDEN_DOCUMENTS_URL
 			)
 		).then(
 			data => ({

--- a/modules/apps/portal-search/portal-search-ranking-web/test/js/components/ResultsRankingForm.es.js
+++ b/modules/apps/portal-search/portal-search-ranking-web/test/js/components/ResultsRankingForm.es.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ResultsRankingForm from 'components/ResultsRankingForm.es';
 import {cleanup, fireEvent, render, waitForElement} from 'react-testing-library';
+import {FETCH_HIDDEN_DOCUMENTS_URL, FETCH_VISIBLE_DOCUMENTS_URL} from 'test/mock-data';
 import 'jest-dom/extend-expect';
 
 jest.mock('utils/api.es');
@@ -23,8 +24,8 @@ describe(
 				const {container} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={'example'}
 					/>
 				);
@@ -40,8 +41,8 @@ describe(
 				const {getByTestId} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -59,8 +60,8 @@ describe(
 				const {getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -80,8 +81,8 @@ describe(
 				const {container} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						initialAliases={['one', 'two', 'three']}
 						searchTerm={''}
 					/>
@@ -102,8 +103,8 @@ describe(
 				const {container} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						initialAliases={['one', 'two', 'three']}
 						searchTerm={''}
 					/>
@@ -126,8 +127,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -149,8 +150,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -174,8 +175,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -197,8 +198,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -222,8 +223,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -245,8 +246,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -272,8 +273,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -297,8 +298,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -326,8 +327,8 @@ describe(
 				const {container, getByTestId, getByText} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -359,8 +360,8 @@ describe(
 				const {container, getByTestId} = render(
 					<ResultsRankingForm
 						cancelUrl={'cancel'}
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm={''}
 					/>
 				);
@@ -383,8 +384,8 @@ describe(
 				const {container, getByTestId} = render(
 					<ResultsRankingForm
 						cancelUrl=""
-						fetchDocumentsHiddenUrl=""
-						fetchDocumentsUrl=""
+						fetchDocumentsHiddenUrl={FETCH_HIDDEN_DOCUMENTS_URL}
+						fetchDocumentsUrl={FETCH_VISIBLE_DOCUMENTS_URL}
 						searchTerm=""
 					/>
 				);

--- a/modules/apps/portal-search/portal-search-ranking-web/test/js/mock-data.js
+++ b/modules/apps/portal-search/portal-search-ranking-web/test/js/mock-data.js
@@ -1,3 +1,7 @@
+export const FETCH_HIDDEN_DOCUMENTS_URL = '/getHidden';
+
+export const FETCH_VISIBLE_DOCUMENTS_URL = '/getVisible';
+
 export function getMockResultsData(
 	size = 10,
 	startId = 0,


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-88817

- This adds the namespace to the parameters being passed while fetching documents.
- Removes `searchIndex` and `hidden` parameters.
- Removes the `keyword` param from the jsp since the `keyword` changes when being used inside the "Add Result" modal.

cc: @oliv-yu