### PR TITLE
[TS] LPS-95116 Liferay allows Expando Fields with a . in the name but throws an exception when attempting to index the

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -54,8 +54,8 @@
 						"store": true,
 						"type": "text"
 					},
-					"match": "expando__keyword__*",
-					"match_mapping_type": "string"
+					"match_mapping_type": "string",
+					"path_match": "expando__keyword__*"
 				}
 			},
 			{
@@ -463,8 +463,8 @@
 						"store": true,
 						"type": "text"
 					},
-					"match": "expando__*",
-					"match_mapping_type": "string"
+					"match_mapping_type": "string",
+					"path_match": "expando__*"
 				}
 			}
 		],

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.junit.AfterClass;
@@ -75,6 +76,25 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 	@AfterClass
 	public static void tearDownClassBaseExpandoTestCase() {
 		RegistryUtil.setRegistry(null);
+	}
+
+	@Test
+	public void testColumnNameWithPeriod() throws Exception {
+		String keywordColumnName =
+			"expando__keyword__custom_fields__column.name";
+		String textColumnName = "expando__custom_fields__column.name";
+
+		Function<String, DocumentCreationHelper> addKeyword =
+			value -> addKeyword(keywordColumnName, value);
+
+		Function<String, DocumentCreationHelper> addText = value -> addText(
+			textColumnName, value);
+
+		addDocuments(addKeyword, Arrays.asList("keyword"));
+		addDocuments(addText, Arrays.asList("text"));
+
+		assertSearch(keywordColumnName, textColumnName, "keyword", 1);
+		assertSearch(keywordColumnName, textColumnName, "text", 1);
 	}
 
 	@Test
@@ -134,18 +154,26 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 	}
 
 	protected DocumentCreationHelper addKeyword(String value) {
-		return document -> {
-			document.addKeyword(Field.STATUS, _FIELD_KEYWORD + value);
+		return addKeyword(_FIELD_KEYWORD, value);
+	}
 
-			document.addKeyword(_FIELD_KEYWORD, value);
+	protected DocumentCreationHelper addKeyword(String name, String value) {
+		return document -> {
+			document.addKeyword(Field.STATUS, name + value);
+
+			document.addKeyword(name, value);
 		};
 	}
 
 	protected DocumentCreationHelper addText(String value) {
-		return document -> {
-			document.addKeyword(Field.STATUS, _FIELD_TEXT + value);
+		return addText(_FIELD_TEXT, value);
+	}
 
-			document.addText(_FIELD_TEXT, value);
+	protected DocumentCreationHelper addText(String name, String value) {
+		return document -> {
+			document.addKeyword(Field.STATUS, name + value);
+
+			document.addText(name, value);
 		};
 	}
 
@@ -153,7 +181,20 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		throws Exception {
 
 		IdempotentRetryAssert.retryAssert(
-			3, TimeUnit.SECONDS, () -> doAssertSearch(keywords, expectedCount));
+			3, TimeUnit.SECONDS,
+			() -> doAssertSearch(
+				_FIELD_KEYWORD, _FIELD_TEXT, keywords, expectedCount));
+	}
+
+	protected void assertSearch(
+			String keywordFieldName, String textFieldName, String keywords,
+			int expectedCount)
+		throws Exception {
+
+		IdempotentRetryAssert.retryAssert(
+			3, TimeUnit.SECONDS,
+			() -> doAssertSearch(
+				keywordFieldName, textFieldName, keywords, expectedCount));
 	}
 
 	protected ExpandoBridge createExpandoBridge(
@@ -203,12 +244,14 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		return expandoBridgeFactory;
 	}
 
-	protected ExpandoBridgeIndexer createExpandoBridgeIndexer() {
+	protected ExpandoBridgeIndexer createExpandoBridgeIndexer(
+		String keywordFieldName, String textFieldName) {
+
 		ExpandoBridgeIndexer expandoBridgeIndexer = Mockito.mock(
 			ExpandoBridgeIndexer.class);
 
 		Mockito.doReturn(
-			_FIELD_KEYWORD
+			keywordFieldName
 		).when(
 			expandoBridgeIndexer
 		).encodeFieldName(
@@ -217,7 +260,7 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		);
 
 		Mockito.doReturn(
-			_FIELD_TEXT
+			textFieldName
 		).when(
 			expandoBridgeIndexer
 		).encodeFieldName(
@@ -270,11 +313,12 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		return expandoColumnLocalService;
 	}
 
-	protected ExpandoQueryContributorHelper
-		createExpandoQueryContributorHelper() {
+	protected ExpandoQueryContributorHelper createExpandoQueryContributorHelper(
+		String keywordFieldName, String textFieldName) {
 
 		return new ExpandoQueryContributorHelper(
-			createExpandoBridgeFactory(), createExpandoBridgeIndexer(),
+			createExpandoBridgeFactory(),
+			createExpandoBridgeIndexer(keywordFieldName, textFieldName),
 			createExpandoColumnLocalService(), null);
 	}
 
@@ -293,7 +337,9 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		return unicodeProperties;
 	}
 
-	protected Void doAssertSearch(String keywords, int expectedCount)
+	protected Void doAssertSearch(
+			String keywordFieldName, String textFieldName, String keywords,
+			int expectedCount)
 		throws Exception {
 
 		BooleanQuery booleanQuery = new BooleanQueryImpl();
@@ -301,7 +347,8 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		SearchContext searchContext = createSearchContext();
 
 		ExpandoQueryContributorHelper expandoQueryContributorHelper =
-			createExpandoQueryContributorHelper();
+			createExpandoQueryContributorHelper(
+				keywordFieldName, textFieldName);
 
 		expandoQueryContributorHelper.setAndSearch(searchContext.isAndSearch());
 		expandoQueryContributorHelper.setBooleanQuery(booleanQuery);

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/ExpandoSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/ExpandoSearchTest.java
@@ -108,6 +108,20 @@ public class ExpandoSearchTest {
 	}
 
 	@Test
+	public void testColumnNameWithPeriod() throws Exception {
+		String columnName = "column.name";
+
+		addExpandoColumn(
+			User.class, columnName, ExpandoColumnConstants.INDEX_TYPE_TEXT);
+
+		String columnValue = "Software Engineer";
+
+		addUser(columnName, columnValue);
+
+		assertSearch(columnValue, columnValue);
+	}
+
+	@Test
 	public void testIndexerWithMultipleSearchClassNames() throws Exception {
 		String columnName = "searchClassNamesColumn";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
@@ -535,12 +535,6 @@ public class Field implements Serializable {
 					"Name must not contain ", StringPool.COMMA, ": ", name));
 		}
 
-		if (name.contains(StringPool.PERIOD)) {
-			throw new IllegalArgumentException(
-				StringBundler.concat(
-					"Name must not contain ", StringPool.PERIOD, ": ", name));
-		}
-
 		if (name.contains(StringPool.POUND)) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(


### PR DESCRIPTION
[LPS-95116](https://issues.liferay.com/browse/LPS-95116)

Hi Bryan,

These changes come from @ericyanLr who made them with POC purpose. I couldn't identify improvement points, but please let me know if you miss anything. For Eric's analysis please see the LPS ticket.

**Additional info:**
* The change requires reindex. Based on the feedback of Tibor Lipusz, the best would be to put this into the 7.2 release.
* 7.0.x backport requires a unix fix, because it comes with Elasticsearch 2.4 by default, which doesn't support dots in field names.