### PR TITLE
LPS-95707 portal-search-web: Properly display value

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayBuilder.java
@@ -37,6 +37,7 @@ public class CustomFilterDisplayBuilder {
 
 		customFilterDisplayContext.setFilterValue(getFilterValue());
 		customFilterDisplayContext.setHeading(getHeading());
+		customFilterDisplayContext.setImmutable(_immutable);
 		customFilterDisplayContext.setParameterName(_parameterName);
 		customFilterDisplayContext.setRenderNothing(isRenderNothing());
 		customFilterDisplayContext.setSearchURL(getURLCurrentPath());

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayBuilder.java
@@ -116,6 +116,11 @@ public class CustomFilterDisplayBuilder {
 	}
 
 	protected String getFilterValue() {
+		if (_immutable) {
+			return SearchOptionalUtil.findFirstPresent(
+				Stream.of(_filterValueOptional), StringPool.BLANK);
+		}
+
 		return SearchOptionalUtil.findFirstPresent(
 			Stream.of(_parameterValueOptional, _filterValueOptional),
 			StringPool.BLANK);

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayContext.java
@@ -35,6 +35,10 @@ public class CustomFilterDisplayContext {
 		return _searchURL;
 	}
 
+	public boolean isImmutable() {
+		return _immutable;
+	}
+
 	public boolean isRenderNothing() {
 		return _renderNothing;
 	}
@@ -45,6 +49,10 @@ public class CustomFilterDisplayContext {
 
 	public void setHeading(String heading) {
 		_heading = heading;
+	}
+
+	public void setImmutable(boolean immutable) {
+		_immutable = immutable;
 	}
 
 	public void setParameterName(String paramName) {
@@ -63,6 +71,7 @@ public class CustomFilterDisplayContext {
 	private String _heading;
 	private String _parameterName;
 	private boolean _renderNothing;
+	private boolean _immutable;
 	private String _searchURL;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/filter/display/context/CustomFilterDisplayContext.java
@@ -69,9 +69,9 @@ public class CustomFilterDisplayContext {
 
 	private String _filterValue;
 	private String _heading;
+	private boolean _immutable;
 	private String _parameterName;
 	private boolean _renderNothing;
-	private boolean _immutable;
 	private String _searchURL;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/view.jsp
@@ -52,10 +52,11 @@ CustomFilterDisplayContext customFilterDisplayContext = (CustomFilterDisplayCont
 				title="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getHeading()) %>"
 			>
 				<aui:form action="<%= customFilterDisplayContext.getSearchURL() %>" method="get" name="customFilterForm">
-					<aui:input cssClass="custom-filter-value-input" data-qa-id="customFilterValueInput" id="<%= renderResponse.getNamespace() + StringUtil.randomId() %>" label="" name="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getParameterName()) %>" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getFilterValue()) %>" />
+					<aui:input cssClass="custom-filter-value-input" data-qa-id="customFilterValueInput" disabled="<%= customFilterDisplayContext.isImmutable() %>" id="<%= renderResponse.getNamespace() + StringUtil.randomId() %>" label="" name="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getParameterName()) %>" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getFilterValue()) %>" />
 
 					<clay:button
 						ariaLabel='<%= LanguageUtil.get(request, "apply") %>'
+						disabled="<%= customFilterDisplayContext.isImmutable() %>"
 						elementClasses="custom-filter-apply-button"
 						label='<%= LanguageUtil.get(request, "apply") %>'
 						size="sm"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/view.jsp
@@ -32,43 +32,36 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 CustomFilterDisplayContext customFilterDisplayContext = (CustomFilterDisplayContext)java.util.Objects.requireNonNull(request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT));
 %>
 
-<c:choose>
-	<c:when test="<%= customFilterDisplayContext.isRenderNothing() %>">
-		<aui:input autocomplete="off" name="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getParameterName()) %>" type="hidden" value="<%= customFilterDisplayContext.getFilterValue() %>" />
-	</c:when>
-	<c:otherwise>
-		<liferay-ui:panel-container
-			extended="<%= true %>"
-			id='<%= renderResponse.getNamespace() + "filterCustomPanelContainer" %>'
-			markupView="lexicon"
-			persistState="<%= true %>"
-		>
-			<liferay-ui:panel
-				collapsible="<%= true %>"
-				cssClass="search-facet"
-				id='<%= renderResponse.getNamespace() + "filterCustomPanel" %>'
-				markupView="lexicon"
-				persistState="<%= true %>"
-				title="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getHeading()) %>"
-			>
-				<aui:form action="<%= customFilterDisplayContext.getSearchURL() %>" method="get" name="customFilterForm">
-					<aui:input cssClass="custom-filter-value-input" data-qa-id="customFilterValueInput" disabled="<%= customFilterDisplayContext.isImmutable() %>" id="<%= renderResponse.getNamespace() + StringUtil.randomId() %>" label="" name="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getParameterName()) %>" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getFilterValue()) %>" />
+<liferay-ui:panel-container
+	extended="<%= true %>"
+	id='<%= renderResponse.getNamespace() + "filterCustomPanelContainer" %>'
+	markupView="lexicon"
+	persistState="<%= true %>"
+>
+	<liferay-ui:panel
+		collapsible="<%= true %>"
+		cssClass="search-facet"
+		id='<%= renderResponse.getNamespace() + "filterCustomPanel" %>'
+		markupView="lexicon"
+		persistState="<%= true %>"
+		title="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getHeading()) %>"
+	>
+		<aui:form action="<%= customFilterDisplayContext.getSearchURL() %>" method="get" name="customFilterForm">
+			<aui:input cssClass="custom-filter-value-input" data-qa-id="customFilterValueInput" disabled="<%= customFilterDisplayContext.isImmutable() %>" id="<%= renderResponse.getNamespace() + StringUtil.randomId() %>" label="" name="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getParameterName()) %>" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getFilterValue()) %>" />
 
-					<clay:button
-						ariaLabel='<%= LanguageUtil.get(request, "apply") %>'
-						disabled="<%= customFilterDisplayContext.isImmutable() %>"
-						elementClasses="custom-filter-apply-button"
-						label='<%= LanguageUtil.get(request, "apply") %>'
-						size="sm"
-						style="secondary"
-						type="submit"
-					/>
-				</aui:form>
-			</liferay-ui:panel>
-		</liferay-ui:panel-container>
+			<clay:button
+				ariaLabel='<%= LanguageUtil.get(request, "apply") %>'
+				disabled="<%= customFilterDisplayContext.isImmutable() %>"
+				elementClasses="custom-filter-apply-button"
+				label='<%= LanguageUtil.get(request, "apply") %>'
+				size="sm"
+				style="secondary"
+				type="submit"
+			/>
+		</aui:form>
+	</liferay-ui:panel>
+</liferay-ui:panel-container>
 
-		<aui:script use="liferay-search-custom-filter">
-			new Liferay.Search.CustomFilter(A.one('#<portlet:namespace/>customFilterForm'));
-		</aui:script>
-	</c:otherwise>
-</c:choose>
+<aui:script use="liferay-search-custom-filter">
+	new Liferay.Search.CustomFilter(A.one('#<portlet:namespace/>customFilterForm'));
+</aui:script>


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-95707

Decided to keep the inputs visible since hiding them for the admin made the portlet more difficult to configure. For `invisible` enabled the input will still be editable, but for `immutability` enabled the input will be disabled.

This also fixes the input value from using the value from the URL when the "immutability" setting is enabled.