### PR TITLE
[TS] LPS-93019 Search scope not working properly

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
@@ -96,7 +96,7 @@ public class SearchBarPortletSharedSearchContributor
 
 		searchRequestBuilder.withSearchContext(
 			searchContext -> searchContext.setGroupIds(
-				new long[] {getScopeGroupId(portletSharedSearchSettings)}));
+				getGroupIds(portletSharedSearchSettings)));
 	}
 
 	protected Optional<Portlet> findTopSearchBarPortletOptional(
@@ -119,17 +119,20 @@ public class SearchBarPortletSharedSearchContributor
 		return searchScopePreference.getSearchScope();
 	}
 
-	protected long[] addScopeGroup(long groupId) {
+	protected long[] getGroupIds(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		ThemeDisplay themeDisplay =
+			portletSharedSearchSettings.getThemeDisplay();
+
 		try {
 			List<Long> groupIds = new ArrayList<>();
 
-			groupIds.add(groupId);
-
-			Group group = groupLocalService.getGroup(groupId);
+			groupIds.add(themeDisplay.getScopeGroupId());
 
 			List<Group> groups = groupLocalService.getGroups(
-				group.getCompanyId(), Layout.class.getName(),
-				group.getGroupId());
+				themeDisplay.getCompanyId(), Layout.class.getName(),
+				themeDisplay.getScopeGroupId());
 
 			for (Group scopeGroup : groups) {
 				groupIds.add(scopeGroup.getGroupId());
@@ -140,7 +143,7 @@ public class SearchBarPortletSharedSearchContributor
 		catch (Exception e) {
 		}
 
-		return new long[] {groupId};
+		return new long[] {themeDisplay.getScopeGroupId()};
 	}
 
 	protected Stream<Portlet> getPortletsStream(ThemeDisplay themeDisplay) {
@@ -152,15 +155,6 @@ public class SearchBarPortletSharedSearchContributor
 		List<Portlet> portlets = layoutTypePortlet.getAllPortlets(false);
 
 		return portlets.stream();
-	}
-
-	protected long getScopeGroupId(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		ThemeDisplay themeDisplay =
-			portletSharedSearchSettings.getThemeDisplay();
-
-		return themeDisplay.getScopeGroupId();
 	}
 
 	protected SearchBarPortletPreferences getSearchBarPortletPreferences(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
@@ -91,8 +91,9 @@ public class SearchBarPortletSharedSearchContributor
 		}
 
 		searchRequestBuilder.withSearchContext(
-			searchContext -> searchContext.setGroupIds(
-				new long[] {getScopeGroupId(portletSharedSearchSettings)}));
+			searchContext -> searchContext.setAttribute(
+				"groupId",
+				String.valueOf(getScopeGroupId(portletSharedSearchSettings))));
 	}
 
 	protected Optional<Portlet> findTopSearchBarPortletOptional(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/query/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/query/GroupIdQueryPreFilterContributor.java
@@ -17,7 +17,6 @@ package com.liferay.portal.search.internal.contributor.query;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
@@ -25,12 +24,9 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -47,7 +43,7 @@ public class GroupIdQueryPreFilterContributor
 	public void contribute(
 		BooleanFilter booleanFilter, SearchContext searchContext) {
 
-		long[] groupIds = getGroupIds(searchContext);
+		long[] groupIds = searchContext.getGroupIds();
 
 		if (ArrayUtil.isEmpty(groupIds) ||
 			((groupIds.length == 1) && (groupIds[0] == 0))) {
@@ -106,57 +102,6 @@ public class GroupIdQueryPreFilterContributor
 		booleanFilter.add(scopeBooleanFilter, BooleanClauseOccur.MUST);
 	}
 
-	protected long[] addScopeGroup(long groupId) {
-		try {
-			List<Long> groupIds = new ArrayList<>();
-
-			groupIds.add(groupId);
-
-			Group group = groupLocalService.getGroup(groupId);
-
-			List<Group> groups = groupLocalService.getGroups(
-				group.getCompanyId(), Layout.class.getName(),
-				group.getGroupId());
-
-			for (Group scopeGroup : groups) {
-				groupIds.add(scopeGroup.getGroupId());
-			}
-
-			return ArrayUtil.toLongArray(groupIds);
-		}
-		catch (Exception e) {
-		}
-
-		return new long[] {groupId};
-	}
-
-	protected long[] getGroupIds(SearchContext searchContext) {
-		long[] groupIds = getGroupIdsFromSearchContext(searchContext);
-
-		if (ArrayUtil.isEmpty(groupIds)) {
-			groupIds = searchContext.getGroupIds();
-		}
-
-		return groupIds;
-	}
-
-	protected long[] getGroupIdsFromSearchContext(SearchContext searchContext) {
-		String groupIdAttribute = GetterUtil.getString(
-			searchContext.getAttribute("groupId"));
-
-		if (Validator.isNull(groupIdAttribute)) {
-			return null;
-		}
-
-		long groupId = GetterUtil.getLong(groupIdAttribute);
-
-		if (groupId == 0) {
-			return _GROUP_IDS_FROM_SEARCH_CONTEXT_DEFAULT;
-		}
-
-		return addScopeGroup(groupId);
-	}
-
 	@Reference
 	protected GroupLocalService groupLocalService;
 
@@ -197,7 +142,5 @@ public class GroupIdQueryPreFilterContributor
 			throw new SystemException(pe);
 		}
 	}
-
-	private static final long[] _GROUP_IDS_FROM_SEARCH_CONTEXT_DEFAULT = {0};
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93019
Similar to https://issues.liferay.com/browse/LPS-36373.

Hey Bryan,

Regarding my changes: I think GroupIdQueryPreFilterContributor is not really a 1in1 replacement of ScopeFacet so altering the actual groupIds may have side-effects. Let's collect the actual scope groupIds where it's coming from (Search Bar) and keep using the searchContext.setGroupIds API to control what groups we want to search in from the business point of view.

Also removed to get the scope group instance, we have everything we need from the themeDisplay.

Author: @istvansajtos
Reviewers: @lipusz
:heavy_check_mark: `ci:test:sf` on https://github.com/lipusz/liferay-portal/pull/270#issuecomment-501353281
:heavy_check_mark: `ci:test:relevant` on https://github.com/lipusz/liferay-portal/pull/270#issuecomment-501624904
:heavy_check_mark: `ci:test:search` on https://github.com/lipusz/liferay-portal/pull/270#issuecomment-501630144
using the latest stable hash from Search CI.

Please, prioritize this because it's been pending for a while because of my fault. :-/

Regards,
Tibor

