### PR TITLE
LPS-95940 Clicking the tag on a search result doesnt add filter after changing parameter name in facet config

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/shared/search/CategoryFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/shared/search/CategoryFacetPortletSharedSearchContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.web.internal.category.facet.portlet.shared.search;
 
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -47,6 +48,13 @@ public class CategoryFacetPortletSharedSearchContributor
 		CategoryFacetPortletPreferences categoryFacetPortletPreferences =
 			new CategoryFacetPortletPreferencesImpl(
 				portletSharedSearchSettings.getPortletPreferencesOptional());
+
+		SearchContext searchContext =
+			portletSharedSearchSettings.getSearchContext();
+
+		searchContext.setAttribute(
+			"categoryParameter",
+			categoryFacetPortletPreferences.getParameterName());
 
 		categoryFacetSearchContributor.contribute(
 			portletSharedSearchSettings.getSearchRequestBuilder(),

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -129,6 +129,14 @@ public class SearchResultSummaryDisplayBuilder {
 		return this;
 	}
 
+	public SearchResultSummaryDisplayBuilder setCategoryParameter(
+		String categoryParameter) {
+
+		_categoryParameter = categoryParameter;
+
+		return this;
+	}
+
 	public SearchResultSummaryDisplayBuilder setCurrentURL(String currentURL) {
 		_currentURL = currentURL;
 
@@ -270,6 +278,14 @@ public class SearchResultSummaryDisplayBuilder {
 		return this;
 	}
 
+	public SearchResultSummaryDisplayBuilder setTagParameter(
+		String tagParameter) {
+
+		_tagParameter = tagParameter;
+
+		return this;
+	}
+
 	public SearchResultSummaryDisplayBuilder setThemeDisplay(
 		ThemeDisplay themeDisplay) {
 
@@ -362,8 +378,9 @@ public class SearchResultSummaryDisplayBuilder {
 			searchResultSummaryDisplayContext.setAssetCategoriesOrTagsVisible(
 				true);
 			searchResultSummaryDisplayContext.setFieldAssetCategoryIds(
-				"category");
-			searchResultSummaryDisplayContext.setFieldAssetTagNames("tag");
+				_categoryParameter);
+			searchResultSummaryDisplayContext.setFieldAssetTagNames(
+				_tagParameter);
 		}
 	}
 
@@ -901,6 +918,7 @@ public class SearchResultSummaryDisplayBuilder {
 	private boolean _abridged;
 	private AssetEntryLocalService _assetEntryLocalService;
 	private AssetRendererFactoryLookup _assetRendererFactoryLookup;
+	private String _categoryParameter;
 	private String _currentURL;
 	private Document _document;
 	private DocumentBuilderFactory _documentBuilderFactory;
@@ -921,6 +939,7 @@ public class SearchResultSummaryDisplayBuilder {
 	private SearchResultPreferences _searchResultPreferences;
 	private SearchResultViewURLSupplier _searchResultViewURLSupplier;
 	private SummaryBuilderFactory _summaryBuilderFactory;
+	private String _tagParameter;
 	private ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -266,8 +266,8 @@ public class SearchResultsPortlet extends MVCPortlet {
 			SearchResultSummaryDisplayContext
 				searchResultSummaryDisplayContext = doBuildSummary(
 					document, renderRequest, renderResponse, themeDisplay,
-					portletURLFactory, searchResultsPortletPreferences,
-					searchResultPreferences);
+					portletURLFactory, searchResponse,
+					searchResultsPortletPreferences, searchResultPreferences);
 
 			if (searchResultSummaryDisplayContext != null) {
 				searchResultsSummariesHolder.put(
@@ -281,10 +281,18 @@ public class SearchResultsPortlet extends MVCPortlet {
 	protected SearchResultSummaryDisplayContext doBuildSummary(
 			Document document, RenderRequest renderRequest,
 			RenderResponse renderResponse, ThemeDisplay themeDisplay,
-			PortletURLFactory portletURLFactory,
+			PortletURLFactory portletURLFactory, SearchResponse searchResponse,
 			SearchResultsPortletPreferences searchResultsPortletPreferences,
 			SearchResultPreferences searchResultPreferences)
 		throws Exception {
+
+		String categoryParameter = searchResponse.withSearchContextGet(
+			searchContext -> (String)searchContext.getAttribute(
+				"categoryParameter"));
+
+		String tagParameter = searchResponse.withSearchContextGet(
+			searchContext -> (String)searchContext.getAttribute(
+				"tagParameter"));
 
 		SearchResultSummaryDisplayBuilder searchResultSummaryDisplayBuilder =
 			new SearchResultSummaryDisplayBuilder();
@@ -293,6 +301,8 @@ public class SearchResultsPortlet extends MVCPortlet {
 			assetEntryLocalService
 		).setAssetRendererFactoryLookup(
 			assetRendererFactoryLookup
+		).setCategoryParameter(
+			categoryParameter
 		).setCurrentURL(
 			getCurrentURL(renderRequest)
 		).setDocument(
@@ -327,6 +337,8 @@ public class SearchResultsPortlet extends MVCPortlet {
 			searchResultPreferences
 		).setSummaryBuilderFactory(
 			summaryBuilderFactory
+		).setTagParameter(
+			tagParameter
 		).setThemeDisplay(
 			themeDisplay
 		);

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/shared/search/TagFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/shared/search/TagFacetPortletSharedSearchContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.web.internal.tag.facet.portlet.shared.search;
 
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.search.facet.tag.TagFacetSearchContributor;
 import com.liferay.portal.search.web.internal.tag.facet.constants.TagFacetPortletKeys;
 import com.liferay.portal.search.web.internal.tag.facet.portlet.TagFacetPortletPreferences;
@@ -42,6 +43,12 @@ public class TagFacetPortletSharedSearchContributor
 		TagFacetPortletPreferences tagFacetPortletPreferences =
 			new TagFacetPortletPreferencesImpl(
 				portletSharedSearchSettings.getPortletPreferencesOptional());
+
+		SearchContext searchContext =
+			portletSharedSearchSettings.getSearchContext();
+
+		searchContext.setAttribute(
+			"tagParameter", tagFacetPortletPreferences.getParameterName());
 
 		tagFacetSearchContributor.contribute(
 			portletSharedSearchSettings.getSearchRequestBuilder(),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95940

Hello @BryanEngler,
This is my current solution for LPS-95940. You can see I use the searchContext to pass along the parameters needed for tags and categories so that they dynamically change with those portlets.

There is a potential issue however, if 2 tag or category portlets with different parameter names are on the Search Results page, then the name used will be inconsistently between the 2 portlet parameter names. This use case doesn't make much sense to me, so I'm not too worried. If we wanted to try to address this by adding ALL available parameter names of tag and category portlets, we would need to change the [SearchResultSummaryDisplayContext](https://github.com/liferay/liferay-portal/blob/a46e31640b7a2a1f32a4616253916399d5421b91/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/SearchResultSummaryDisplayContext.java#L233-L235) structure as well as the [jsp](https://github.com/liferay/liferay-portal/blob/722f4eeea131fd7ea77a81d63219b5a35b979a65/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp#L179-L191). Let me know if you want that done.