### PR TITLE
LPS-97585

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
@@ -56,6 +56,13 @@
 				"stopwords": "_spanish_",
 				"type": "stop"
 			}
+		},
+		"normalizer": {
+			"keyword_lowercase": {
+				"type": "custom",
+				"char_filter": [],
+				"filter": ["lowercase"]
+			}
 		}
 	}
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
@@ -59,9 +59,11 @@
 		},
 		"normalizer": {
 			"keyword_lowercase": {
-				"type": "custom",
 				"char_filter": [],
-				"filter": ["lowercase"]
+				"filter": [
+					"lowercase"
+				],
+				"type": "custom"
 			}
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
@@ -59,11 +59,7 @@
 		},
 		"normalizer": {
 			"keyword_lowercase": {
-				"char_filter": [],
-				"filter": [
-					"lowercase"
-				],
-				"type": "custom"
+				"filter": "lowercase"
 			}
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -50,9 +50,9 @@
 			{
 				"template_expando_keyword": {
 					"mapping": {
-						"analyzer" : "keyword_lowercase",
+						"normalizer": "keyword_lowercase",
 						"store": true,
-						"type": "text"
+						"type": "keyword"
 					},
 					"match": "expando__keyword__*",
 					"match_mapping_type": "string"

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -52,9 +52,9 @@
 					{
 						"template_expando_keyword" : {
 							"mapping" : {
-								"analyzer" : "keyword_lowercase",
+								"normalizer" : "keyword_lowercase",
 								"store" : true,
-								"type" : "text"
+								"type" : "keyword"
 							},
 							"match" : "expando__keyword__*",
 							"match_mapping_type" : "string"

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/ExpandoSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/ExpandoSearchTest.java
@@ -145,6 +145,8 @@ public class ExpandoSearchTest {
 
 		addUser();
 
+		columnValue = StringUtil.toLowerCase(columnValue);
+
 		assertSearch("Software Engineer", columnValue);
 		assertSearch("\"Software Engineer\"", columnValue);
 		assertSearch("software engineer", columnValue);
@@ -186,8 +188,9 @@ public class ExpandoSearchTest {
 			"Software", "SoftWare", "softWare", "software"
 		};
 
-		for (String columnValue : columnValues) {
-			addUser(columnName, columnValue);
+		for (int i = 0; i < columnValues.length; i++) {
+			addUser(columnName, columnValues[i]);
+			columnValues[i] = StringUtil.toLowerCase(columnValues[i]);
 		}
 
 		addUser(columnName, RandomTestUtil.randomString());


### PR DESCRIPTION
Notes from @katienesterovich:

> https://issues.liferay.com/browse/LPS-97585
> 
> Fix adds a normalizer for indexing which converts all keywords to lowercase values - this returns hits in all lowercase and guarantees that we find matches regardless of their case.
> 
> For example,
> 
>     * ```
>          `dog`, `Dog`, `DOG` entries are converted to `dog` for indexing
>       ```
> 
>     * ```
>          Searching for `dog`, `Dog`, or `DOG` --> returns all 3 entries
>       ```
> 
> 
> I verified that the fix works and ran source formatter, rebased to master.
> 
> Fix does not break related [LPS-69574](https://issues.liferay.com/browse/LPS-69574).
> 
> Note: to verify, deploy and Reindex all searches indexes in Control Panel > Configuration > Search

Resent from https://github.com/SamZiemer/liferay-portal/pull/695 to address concerns with integration tests.

Sincerely,
Brian Kim