### PR TITLE
[TS] LPS-105532 Duplicate re-indexes created in default company (Liferay-0 index)

### DIFF
--- a/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/internal/search/AccountIndexer.java
+++ b/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/internal/search/AccountIndexer.java
@@ -19,6 +19,8 @@ import com.liferay.expando.kernel.util.ExpandoBridgeIndexerUtil;
 import com.liferay.mail.reader.model.Account;
 import com.liferay.mail.reader.service.AccountLocalService;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -134,7 +136,19 @@ public class AccountIndexer extends BaseIndexer<Account> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			accountLocalService.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(Account account) -> {
 				try {

--- a/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/internal/search/FolderIndexer.java
+++ b/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/internal/search/FolderIndexer.java
@@ -19,6 +19,8 @@ import com.liferay.expando.kernel.util.ExpandoBridgeIndexerUtil;
 import com.liferay.mail.reader.model.Folder;
 import com.liferay.mail.reader.service.FolderLocalService;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -136,7 +138,19 @@ public class FolderIndexer extends BaseIndexer<Folder> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			folderLocalService.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(Folder folder) -> {
 				try {

--- a/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/internal/search/MessageIndexer.java
+++ b/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/internal/search/MessageIndexer.java
@@ -19,6 +19,8 @@ import com.liferay.expando.kernel.util.ExpandoBridgeIndexerUtil;
 import com.liferay.mail.reader.model.Message;
 import com.liferay.mail.reader.service.MessageLocalService;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -105,7 +107,19 @@ public class MessageIndexer extends BaseIndexer<Message> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			messageLocalService.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(Message message) -> {
 				try {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceIndexer.java
@@ -18,6 +18,8 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -105,7 +107,19 @@ public class DDMFormInstanceIndexer extends BaseIndexer<DDMFormInstance> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			ddmFormInstanceLocalService.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(DDMFormInstance ddmFormInstance) -> {
 				try {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
@@ -332,6 +332,11 @@ public class DDMFormInstanceRecordIndexer
 
 		indexableActionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+
 				Property ddmFormInstanceRecordIdProperty =
 					PropertyFactoryUtil.forName("formInstanceRecordId");
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -32,6 +32,8 @@ import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -868,7 +870,19 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 				});
 		}
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setSearchEngineId(getSearchEngineId());
 
 		indexableActionableDynamicQuery.performActions();

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalFolderIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalFolderIndexer.java
@@ -18,6 +18,8 @@ import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -188,7 +190,19 @@ public class JournalFolderIndexer
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			_journalFolderLocalService.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalFolder folder) -> {
 				try {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -247,10 +247,15 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 
 		indexableActionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
-				Property property = PropertyFactoryUtil.forName("status");
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
 
 				dynamicQuery.add(
-					property.eq(WorkflowConstants.STATUS_APPROVED));
+					statusProperty.eq(WorkflowConstants.STATUS_APPROVED));
 			});
 		indexableActionableDynamicQuery.setCompanyId(companyId);
 		indexableActionableDynamicQuery.setPerformActionMethod(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiNodeIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiNodeIndexer.java
@@ -141,10 +141,15 @@ public class WikiNodeIndexer extends BaseIndexer<WikiNode> {
 
 		indexableActionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
-				Property property = PropertyFactoryUtil.forName("status");
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
 
 				dynamicQuery.add(
-					property.eq(WorkflowConstants.STATUS_APPROVED));
+					statusProperty.eq(WorkflowConstants.STATUS_APPROVED));
 			});
 		indexableActionableDynamicQuery.setCompanyId(companyId);
 		indexableActionableDynamicQuery.setPerformActionMethod(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -333,7 +333,19 @@ public class WikiPageIndexer
 		ActionableDynamicQuery actionableDynamicQuery =
 			_wikiNodeLocalService.getActionableDynamicQuery();
 
-		actionableDynamicQuery.setCompanyId(companyId);
+		if (companyId == 0) {
+			actionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		}
+		else {
+			actionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		actionableDynamicQuery.setPerformActionMethod(
 			(WikiNode node) -> reindexPages(
 				companyId, node.getGroupId(), node.getNodeId()));

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetTagIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetTagIndexer.java
@@ -17,6 +17,8 @@ package com.liferay.portlet.asset.util;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -131,7 +133,18 @@ public class AssetTagIndexer extends BaseIndexer<AssetTag> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			AssetTagLocalServiceUtil.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if(companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		} else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(AssetTag tag) -> {
 				try {

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetVocabularyIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetVocabularyIndexer.java
@@ -17,6 +17,8 @@ package com.liferay.portlet.asset.util;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -168,7 +170,18 @@ public class AssetVocabularyIndexer extends BaseIndexer<AssetVocabulary> {
 			AssetVocabularyLocalServiceUtil.
 				getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if(companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		} else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(AssetVocabulary assetVocabulary) -> {
 				try {

--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/ContactIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/ContactIndexer.java
@@ -15,6 +15,8 @@
 package com.liferay.portlet.usersadmin.util;
 
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -174,7 +176,18 @@ public class ContactIndexer extends BaseIndexer<Contact> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			ContactLocalServiceUtil.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if(companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		} else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(Contact contact) -> {
 				try {

--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/OrganizationIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/OrganizationIndexer.java
@@ -17,6 +17,8 @@ package com.liferay.portlet.usersadmin.util;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -272,7 +274,18 @@ public class OrganizationIndexer extends BaseIndexer<Organization> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			OrganizationLocalServiceUtil.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if(companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		} else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(Organization organization) -> {
 				try {

--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/UserIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/UserIndexer.java
@@ -15,6 +15,8 @@
 package com.liferay.portlet.usersadmin.util;
 
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.NoSuchContactException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -388,7 +390,18 @@ public class UserIndexer extends BaseIndexer<User> {
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			UserLocalServiceUtil.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setCompanyId(companyId);
+		if(companyId == 0) {
+			indexableActionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+				});
+		} else {
+			indexableActionableDynamicQuery.setCompanyId(companyId);
+		}
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(User user) -> {
 				if (!user.isDefaultUser()) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-105532

Resent after https://github.com/BryanEngler/liferay-portal/pull/451

The simple approach of changing the addDefaultCriteria() in DefaultActionableDynamicQuery.java https://github.com/BryanEngler/liferay-portal/pull/451 produced numerous test failures: https://github.com/BryanEngler/liferay-portal/pull/451#issuecomment-563585138 and https://github.com/BryanEngler/liferay-portal/pull/451#issuecomment-563639199. Additionally, it silently changes the query parameters for ActionableDynamicQuerys. I'm looking at instead changing each reindexible asset's query.

Previous Notes:
> **Problem:** [LPS-93762](https://issues.liferay.com/browse/LPS-93762) added [code](https://github.com/liferay/liferay-portal/commit/24b79f7d8eed9c4d5c1ec4f9fe5cdc416c753eca#diff-b26d0aad6be702e6d578116684b7a977R112-R114) which includes companyId 0 during reindexing. However, the companyId is ignored in Indexers because DynamicActionableQueries were relying on the [addDefaultCriteria()](https://github.com/liferay/liferay-portal/blob/5dda80c446339f09a0332a44c58b4a935769c3ed/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQuery.java#L219-L224) to fill in the companyId. In this new case of 0, the companyId criteria never added resulting in all assets being returned by their indexers.
> 
> **Solution:** Change the addDefaultCriteria() to include 0. 
> 
> This is a far reaching change, but it's much cleaner than adding the companyId  criteria to each indexer. See discussion here: https://liferay.slack.com/archives/CKY6GP7BL/p1575925367179600
> 
> If you could direct me to the correct class to put a test for this and a similar indexer test I could add that to the PR.