### PR TITLE
[TS] LPS-105532 Only index ConfigurationModels during liferay-0

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
@@ -111,7 +111,21 @@ public class SearchEngineInitializer implements Runnable {
 			List<FutureTask<Void>> futureTasks = new ArrayList<>();
 			Set<String> searchEngineIds = new HashSet<>();
 
-			for (Indexer<?> indexer : IndexerRegistryUtil.getIndexers()) {
+			Set<Indexer<?>> indexers = null;
+
+			if (_companyId == 0) {
+				indexers = new HashSet<>();
+
+				indexers.add(
+					IndexerRegistryUtil.getIndexer(
+						"com.liferay.configuration.admin.web.internal.model." +
+							"ConfigurationModel"));
+			}
+			else {
+				indexers = IndexerRegistryUtil.getIndexers();
+			}
+
+			for (Indexer<?> indexer : indexers) {
 				String searchEngineId = indexer.getSearchEngineId();
 
 				if (searchEngineIds.add(searchEngineId)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-105532
https://issues.liferay.com/browse/PTR-1378

Previous pulls:
https://github.com/BryanEngler/liferay-portal/pull/451
https://github.com/BryanEngler/liferay-portal/pull/452

This approach assumes that only ConfigurationModels are stored in the system index. So far it seems like the least disruptive approach we can take.

I tested successfully here: https://github.com/joshuacords/liferay-portal/pull/62#issuecomment-566746271

Let me know your thoughts. 