### PR TITLE
[TS] LPS-108052 remove ignored prefilter from solr

### DIFF
--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/SolrIndexWriter.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/SolrIndexWriter.java
@@ -19,16 +19,12 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BaseIndexWriter;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.filter.BooleanFilter;
-import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
-import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.search.suggest.SpellCheckIndexWriter;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
@@ -220,23 +216,14 @@ public class SolrIndexWriter extends BaseIndexWriter {
 		try {
 			BooleanQuery booleanQuery = new BooleanQueryImpl();
 
-			booleanQuery.add(new MatchAllQuery(), BooleanClauseOccur.MUST);
-
-			BooleanFilter booleanFilter = new BooleanFilter();
-
 			long companyId = searchContext.getCompanyId();
 
 			if (companyId > 0) {
-				booleanFilter.add(
-					new TermFilter(Field.COMPANY_ID, String.valueOf(companyId)),
-					BooleanClauseOccur.MUST);
+				booleanQuery.addRequiredTerm(
+					Field.COMPANY_ID, String.valueOf(companyId));
 			}
 
-			booleanFilter.add(
-				new TermFilter(Field.ENTRY_CLASS_NAME, className),
-				BooleanClauseOccur.MUST);
-
-			booleanQuery.setPreBooleanFilter(booleanFilter);
+			booleanQuery.addRequiredTerm(Field.ENTRY_CLASS_NAME, className);
 
 			DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
 				new DeleteByQueryDocumentRequest(

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/logging/SolrIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/logging/SolrIndexWriterExceptionsTest.java
@@ -119,9 +119,7 @@ public class SolrIndexWriterExceptionsTest extends BaseIndexingTestCase {
 
 	@Test
 	public void testDeleteEntityDocuments() {
-		expectedException.expect(HttpSolrClient.RemoteSolrException.class);
-		expectedException.expectMessage(
-			"Problem accessing /solr/liferay/" + _COLLECTION_NAME);
+		expectedException.expect(java.lang.NullPointerException.class);
 
 		IndexWriter indexWriter = getIndexWriter();
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.search.query.FieldQueryFactory;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.aggregation.Aggregation;
@@ -38,14 +39,20 @@ import com.liferay.portal.search.aggregation.Aggregations;
 import com.liferay.portal.search.aggregation.HierarchicalAggregationResult;
 import com.liferay.portal.search.aggregation.bucket.Bucket;
 import com.liferay.portal.search.aggregation.pipeline.PipelineAggregation;
+import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.geolocation.GeoBuilders;
 import com.liferay.portal.search.highlight.Highlights;
 import com.liferay.portal.search.internal.aggregation.AggregationsImpl;
+import com.liferay.portal.search.internal.analysis.DescriptionFieldQueryBuilder;
+import com.liferay.portal.search.internal.analysis.SimpleKeywordTokenizer;
+import com.liferay.portal.search.internal.analysis.SubstringFieldQueryBuilder;
+import com.liferay.portal.search.internal.expando.ExpandoFieldQueryBuilderFactory;
 import com.liferay.portal.search.internal.geolocation.GeoBuildersImpl;
 import com.liferay.portal.search.internal.highlight.HighlightsImpl;
 import com.liferay.portal.search.internal.legacy.searcher.SearchRequestBuilderImpl;
 import com.liferay.portal.search.internal.legacy.searcher.SearchResponseBuilderImpl;
+import com.liferay.portal.search.internal.query.FieldQueryFactoryImpl;
 import com.liferay.portal.search.internal.query.QueriesImpl;
 import com.liferay.portal.search.internal.rescore.RescoreBuilderFactoryImpl;
 import com.liferay.portal.search.internal.script.ScriptsImpl;
@@ -60,6 +67,9 @@ import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.SearchMapUtil;
+import com.liferay.registry.BasicRegistryImpl;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
 
 import java.io.Serializable;
 
@@ -92,6 +102,14 @@ public abstract class BaseIndexingTestCase {
 		_indexingFixture = null;
 
 		_documentFixture.setUp();
+
+		Registry registry = new BasicRegistryImpl();
+
+		registry.registerService(
+			FieldQueryFactory.class,
+			createFieldQueryFactory(createExpandoFieldQueryBuilderFactory()));
+
+		RegistryUtil.setRegistry(registry);
 	}
 
 	@AfterClass
@@ -130,6 +148,43 @@ public abstract class BaseIndexingTestCase {
 
 	@Rule
 	public TestName testName = new TestName();
+
+	protected static DescriptionFieldQueryBuilder
+		createDescriptionFieldQueryBuilder() {
+
+		return new DescriptionFieldQueryBuilder() {
+			{
+				keywordTokenizer = new SimpleKeywordTokenizer();
+			}
+		};
+	}
+
+	protected static ExpandoFieldQueryBuilderFactory
+		createExpandoFieldQueryBuilderFactory() {
+
+		return new ExpandoFieldQueryBuilderFactory() {
+			{
+				substringQueryBuilder = new SubstringFieldQueryBuilder() {
+					{
+						keywordTokenizer = new SimpleKeywordTokenizer();
+					}
+				};
+			}
+		};
+	}
+
+	protected static FieldQueryFactoryImpl createFieldQueryFactory(
+		FieldQueryBuilderFactory fieldQueryBuilderFactory) {
+
+		return new FieldQueryFactoryImpl() {
+			{
+				descriptionFieldQueryBuilder =
+					createDescriptionFieldQueryBuilder();
+
+				addFieldQueryBuilderFactory(fieldQueryBuilderFactory);
+			}
+		};
+	}
 
 	protected static <K, V> Map<K, V> toMap(K key, V value) {
 		return Collections.singletonMap(key, value);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-108052
https://issues.liferay.com/browse/LPP-36209

Tested here: https://github.com/joshuacords/liferay-portal/pull/64/#issuecomment-582728310
Test failure notes here: https://github.com/joshuacords/liferay-portal/pull/64/#issuecomment-582996351

**Problem:** https://issues.liferay.com/browse/LPS-86743 changed Solr's implementation of Low Level Search Engine Adapter API. In particular these [changes](https://github.com/brianchandotcom/liferay-portal/pull/75735/commits/1699da014ed0d208ffcb3288f752f46c0e97878d#diff-283387a568311f2aa49c0f2b10c3d4ecL166-R251) mirrored the Elasticsearch approach. However, they rely on setting a [booleanPrefilter](https://github.com/brianchandotcom/liferay-portal/pull/75735/commits/1699da014ed0d208ffcb3288f752f46c0e97878d#diff-283387a568311f2aa49c0f2b10c3d4ecR239). Unlike [Elasticsearch](https://github.com/liferay/liferay-portal/blob/242542469cc16965c5b86fc19dcaf28649fc9931/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/legacy/query/BooleanQueryTranslatorImpl.java#L40-L73), Solr's [translate method ](https://github.com/liferay/liferay-portal/blob/98c9f5f66aeb4fceba67fde613fd529b8c5c0867/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/query/BooleanQueryTranslatorImpl.java#L36-L55) doesn't consider prefilters. This is because Solr does not handle nested filters. While I initially tried changing the translate method, a change here is impossible because we can't put a filter or a string into the lucene query which must be returned.

**Solution:** After talking with Andre, removing the filter from the deleteEntityDocuments() and flattening the query make the most sense. It removes the prefilter from Solr's implementation. Additionally filter caching on a delete method is unnecessary. The one side effect is the query uses a MUST, SHOULD, SHOULD clause where only a MUST clause is necessary. An example of it looks like this: `{MUST(
	{booleanClauses=[
		{MUST(
			{analyzer=null, className=MatchQuery, cutOffFrequency=null, field=entryClassName, fuzziness=null, fuzzyTranspositions=null, lenient=null, maxExpansions=null, minShouldMatch=null, operator=null, prefixLength=null, slop=null, type=null, value=com.liferay.journal.model.JournalArticle})
		}, 
		{SHOULD(
			{analyzer=null, className=MatchQuery, cutOffFrequency=null, field=entryClassName, fuzziness=null, fuzzyTranspositions=null, lenient=null, maxExpansions=null, minShouldMatch=null, operator=null, prefixLength=null, slop=50, type=PHRASE, value=com.liferay.journal.model.JournalArticle})
		}, 
		{SHOULD(
			{analyzer=null, className=MatchQuery, cutOffFrequency=null, field=entryClassName, fuzziness=null, fuzzyTranspositions=null, lenient=null, maxExpansions=null, minShouldMatch=null, operator=null, prefixLength=null, slop=null, type=PHRASE, value=com.liferay.journal.model.JournalArticle})}
	], className=BooleanQueryImpl})}` 
I don't know of anyway around this behavior or even if it really matters.

Lastly, I fixed the test which broke because `java.lang.NoClassDefFoundError: Could not initialize class com.liferay.portal.kernel.search.query.FieldQueryFactoryUtil`. The unit test needed to register a FieldQueryFactory which is used inside of the new use of booleanQuery.