### PR TITLE
[TS] LPS-149028

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -555,6 +555,56 @@
 					"match": "expando__*",
 					"match_mapping_type": "string"
 				}
+			},
+			{
+				"template_expando_double_sortable": {
+					"mapping": {
+						"store": true,
+						"type": "double"
+					},
+					"match": "expando__*Double_sortable",
+					"match_mapping_type": "double"
+				}
+			},
+			{
+				"template_expando_float_sortable": {
+					"mapping": {
+						"store": true,
+						"type": "float"
+					},
+					"match": "expando__*_Float_sortable",
+					"match_mapping_type": "double"
+				}
+			},
+			{
+				"template_expando_integer_sortable": {
+					"mapping": {
+						"store": true,
+						"type": "integer"
+					},
+					"match": "expando__*_Integer_sortable",
+					"match_mapping_type": "long"
+				}
+			},
+			{
+				"template_expando_long_sortable": {
+					"mapping": {
+						"store": true,
+						"type": "long"
+					},
+					"match": "expando__*_Long_sortable",
+					"match_mapping_type": "long"
+				}
+			},
+			{
+				"template_expando_short_sortable": {
+					"mapping": {
+						"store": true,
+						"type": "short"
+					},
+					"match": "expando__*_Short_sortable",
+					"match_mapping_type": "long"
+				}
 			}
 		],
 		"properties": {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
@@ -228,6 +228,24 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_TEXT)
 		);
 
+		Mockito.doReturn(
+			_FIELD_KEYWORD
+		).when(
+			expandoBridgeIndexer
+		).encodeIndexedFieldName(
+			Mockito.anyString(), Matchers.eq(ExpandoColumnConstants.STRING),
+			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
+		);
+
+		Mockito.doReturn(
+			_FIELD_TEXT
+		).when(
+			expandoBridgeIndexer
+		).encodeIndexedFieldName(
+			Mockito.anyString(), Matchers.eq(ExpandoColumnConstants.STRING),
+			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_TEXT)
+		);
+
 		return expandoBridgeIndexer;
 	}
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
@@ -228,23 +228,23 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_TEXT)
 		);
 
-		Mockito.doReturn(
-			_FIELD_KEYWORD
-		).when(
-			expandoBridgeIndexer
-		).encodeIndexedFieldName(
-			Mockito.anyString(), Matchers.eq(ExpandoColumnConstants.STRING),
-			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
-		);
-
-		Mockito.doReturn(
-			_FIELD_TEXT
-		).when(
-			expandoBridgeIndexer
-		).encodeIndexedFieldName(
-			Mockito.anyString(), Matchers.eq(ExpandoColumnConstants.STRING),
-			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_TEXT)
-		);
+//		Mockito.doReturn(
+//			_FIELD_KEYWORD
+//		).when(
+//			expandoBridgeIndexer
+//		).encodeSortableFieldName(
+//			Mockito.anyString(), Matchers.eq(ExpandoColumnConstants.STRING),
+//			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
+//		);
+//
+//		Mockito.doReturn(
+//			_FIELD_TEXT
+//		).when(
+//			expandoBridgeIndexer
+//		).encodeSortableFieldName(
+//			Mockito.anyString(), Matchers.eq(ExpandoColumnConstants.STRING),
+//			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_TEXT)
+//		);
 
 		return expandoBridgeIndexer;
 	}

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
@@ -173,7 +173,7 @@ public class OrganizationExpandoColumnModelListener
 		String encodedName = _encodeName(expandoColumn);
 
 		String encodedIndexedFieldName =
-			_expandoBridgeIndexer.encodeIndexedFieldName(expandoColumn);
+			_expandoBridgeIndexer.encodeSortableFieldName(expandoColumn);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
@@ -172,8 +172,9 @@ public class OrganizationExpandoColumnModelListener
 
 		String encodedName = _encodeName(expandoColumn);
 
-		String encodedIndexedFieldName = _expandoBridgeIndexer.encodeFieldName(
-			expandoColumn.getName(), expandoColumn.getType(), indexType);
+		String encodedIndexedFieldName =
+			_expandoBridgeIndexer.encodeIndexedFieldName(
+				expandoColumn.getName(), expandoColumn.getType(), indexType);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
@@ -173,7 +173,7 @@ public class OrganizationExpandoColumnModelListener
 		String encodedName = _encodeName(expandoColumn);
 
 		String encodedIndexedFieldName = _expandoBridgeIndexer.encodeFieldName(
-			expandoColumn.getName(), indexType);
+			expandoColumn.getName(), expandoColumn.getType(), indexType);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
@@ -173,8 +173,7 @@ public class OrganizationExpandoColumnModelListener
 		String encodedName = _encodeName(expandoColumn);
 
 		String encodedIndexedFieldName =
-			_expandoBridgeIndexer.encodeIndexedFieldName(
-				expandoColumn.getName(), expandoColumn.getType(), indexType);
+			_expandoBridgeIndexer.encodeIndexedFieldName(expandoColumn);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/OrganizationExpandoColumnModelListener.java
@@ -172,20 +172,20 @@ public class OrganizationExpandoColumnModelListener
 
 		String encodedName = _encodeName(expandoColumn);
 
-		String encodedIndexedFieldName =
+		String encodedSortableFieldName =
 			_expandoBridgeIndexer.encodeSortableFieldName(expandoColumn);
 
 		EntityField entityField = null;
 
 		if (expandoColumn.getType() == ExpandoColumnConstants.BOOLEAN) {
 			entityField = new BooleanEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 		else if (expandoColumn.getType() == ExpandoColumnConstants.DATE) {
 			entityField = new DateTimeEntityField(
 				encodedName,
-				locale -> Field.getSortableFieldName(encodedIndexedFieldName),
-				locale -> encodedIndexedFieldName);
+				locale -> Field.getSortableFieldName(encodedSortableFieldName),
+				locale -> encodedSortableFieldName);
 		}
 		else if ((expandoColumn.getType() == ExpandoColumnConstants.DOUBLE) ||
 				 (expandoColumn.getType() ==
@@ -195,7 +195,7 @@ public class OrganizationExpandoColumnModelListener
 					 ExpandoColumnConstants.FLOAT_ARRAY)) {
 
 			entityField = new DoubleEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 		else if ((expandoColumn.getType() == ExpandoColumnConstants.INTEGER) ||
 				 (expandoColumn.getType() ==
@@ -208,7 +208,7 @@ public class OrganizationExpandoColumnModelListener
 					 ExpandoColumnConstants.SHORT_ARRAY)) {
 
 			entityField = new IntegerEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 		else if (expandoColumn.getType() ==
 					ExpandoColumnConstants.STRING_LOCALIZED) {
@@ -216,11 +216,11 @@ public class OrganizationExpandoColumnModelListener
 			entityField = new StringEntityField(
 				encodedName,
 				locale -> Field.getLocalizedName(
-					locale, encodedIndexedFieldName));
+					locale, encodedSortableFieldName));
 		}
 		else {
 			entityField = new StringEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 
 		return Optional.of(entityField);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
@@ -178,20 +178,20 @@ public class UserExpandoColumnModelListener
 			_entityModelFieldMapper.getExpandoColumnEntityFieldName(
 				expandoColumn);
 
-		String encodedIndexedFieldName =
+		String encodedSortableFieldName =
 			_expandoBridgeIndexer.encodeSortableFieldName(expandoColumn);
 
 		EntityField entityField = null;
 
 		if (expandoColumn.getType() == ExpandoColumnConstants.BOOLEAN) {
 			entityField = new BooleanEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 		else if (expandoColumn.getType() == ExpandoColumnConstants.DATE) {
 			entityField = new DateTimeEntityField(
 				encodedName,
-				locale -> Field.getSortableFieldName(encodedIndexedFieldName),
-				locale -> encodedIndexedFieldName);
+				locale -> Field.getSortableFieldName(encodedSortableFieldName),
+				locale -> encodedSortableFieldName);
 		}
 		else if ((expandoColumn.getType() == ExpandoColumnConstants.DOUBLE) ||
 				 (expandoColumn.getType() ==
@@ -201,7 +201,7 @@ public class UserExpandoColumnModelListener
 					 ExpandoColumnConstants.FLOAT_ARRAY)) {
 
 			entityField = new DoubleEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 		else if ((expandoColumn.getType() == ExpandoColumnConstants.INTEGER) ||
 				 (expandoColumn.getType() ==
@@ -214,7 +214,7 @@ public class UserExpandoColumnModelListener
 					 ExpandoColumnConstants.SHORT_ARRAY)) {
 
 			entityField = new IntegerEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 		else if (expandoColumn.getType() ==
 					ExpandoColumnConstants.STRING_LOCALIZED) {
@@ -222,11 +222,11 @@ public class UserExpandoColumnModelListener
 			entityField = new StringEntityField(
 				encodedName,
 				locale -> Field.getLocalizedName(
-					locale, encodedIndexedFieldName));
+					locale, encodedSortableFieldName));
 		}
 		else {
 			entityField = new StringEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName, locale -> encodedSortableFieldName);
 		}
 
 		return Optional.of(entityField);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
@@ -179,8 +179,7 @@ public class UserExpandoColumnModelListener
 				expandoColumn);
 
 		String encodedIndexedFieldName =
-			_expandoBridgeIndexer.encodeIndexedFieldName(
-				expandoColumn.getName(), expandoColumn.getType(), indexType);
+			_expandoBridgeIndexer.encodeIndexedFieldName(expandoColumn);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
@@ -179,7 +179,7 @@ public class UserExpandoColumnModelListener
 				expandoColumn);
 
 		String encodedIndexedFieldName =
-			_expandoBridgeIndexer.encodeIndexedFieldName(expandoColumn);
+			_expandoBridgeIndexer.encodeSortableFieldName(expandoColumn);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
@@ -201,7 +201,8 @@ public class UserExpandoColumnModelListener
 					 ExpandoColumnConstants.FLOAT_ARRAY)) {
 
 			entityField = new DoubleEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName,
+				locale -> encodedIndexedFieldName + "_Number_sortable");
 		}
 		else if ((expandoColumn.getType() == ExpandoColumnConstants.INTEGER) ||
 				 (expandoColumn.getType() ==
@@ -214,7 +215,8 @@ public class UserExpandoColumnModelListener
 					 ExpandoColumnConstants.SHORT_ARRAY)) {
 
 			entityField = new IntegerEntityField(
-				encodedName, locale -> encodedIndexedFieldName);
+				encodedName,
+				locale -> encodedIndexedFieldName + "_Number_sortable");
 		}
 		else if (expandoColumn.getType() ==
 					ExpandoColumnConstants.STRING_LOCALIZED) {

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
@@ -178,8 +178,9 @@ public class UserExpandoColumnModelListener
 			_entityModelFieldMapper.getExpandoColumnEntityFieldName(
 				expandoColumn);
 
-		String encodedIndexedFieldName = _expandoBridgeIndexer.encodeFieldName(
-			expandoColumn.getName(), expandoColumn.getType(), indexType);
+		String encodedIndexedFieldName =
+			_expandoBridgeIndexer.encodeIndexedFieldName(
+				expandoColumn.getName(), expandoColumn.getType(), indexType);
 
 		EntityField entityField = null;
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserExpandoColumnModelListener.java
@@ -179,7 +179,7 @@ public class UserExpandoColumnModelListener
 				expandoColumn);
 
 		String encodedIndexedFieldName = _expandoBridgeIndexer.encodeFieldName(
-			expandoColumn.getName(), indexType);
+			expandoColumn.getName(), expandoColumn.getType(), indexType);
 
 		EntityField entityField = null;
 
@@ -201,8 +201,7 @@ public class UserExpandoColumnModelListener
 					 ExpandoColumnConstants.FLOAT_ARRAY)) {
 
 			entityField = new DoubleEntityField(
-				encodedName,
-				locale -> encodedIndexedFieldName + "_Number_sortable");
+				encodedName, locale -> encodedIndexedFieldName);
 		}
 		else if ((expandoColumn.getType() == ExpandoColumnConstants.INTEGER) ||
 				 (expandoColumn.getType() ==
@@ -215,8 +214,7 @@ public class UserExpandoColumnModelListener
 					 ExpandoColumnConstants.SHORT_ARRAY)) {
 
 			entityField = new IntegerEntityField(
-				encodedName,
-				locale -> encodedIndexedFieldName + "_Number_sortable");
+				encodedName, locale -> encodedIndexedFieldName);
 		}
 		else if (expandoColumn.getType() ==
 					ExpandoColumnConstants.STRING_LOCALIZED) {

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -64,7 +64,14 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 	@Override
 	public String encodeFieldName(String columnName, int indexType) {
-		StringBundler sb = new StringBundler(6);
+		return encodeFieldName(columnName, 0, indexType);
+	}
+
+	@Override
+	public String encodeFieldName(
+		String columnName, int columnType, int indexType) {
+
+		StringBundler sb = new StringBundler(7);
 
 		sb.append(FIELD_NAMESPACE);
 		sb.append(StringPool.DOUBLE_UNDERLINE);
@@ -77,6 +84,20 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 			StringUtil.toLowerCase(ExpandoTableConstants.DEFAULT_TABLE_NAME));
 		sb.append(StringPool.DOUBLE_UNDERLINE);
 		sb.append(columnName);
+
+		if ((columnType == ExpandoColumnConstants.DOUBLE) ||
+			(columnType == ExpandoColumnConstants.DOUBLE_ARRAY) ||
+			(columnType == ExpandoColumnConstants.FLOAT) ||
+			(columnType == ExpandoColumnConstants.FLOAT_ARRAY) ||
+			(columnType == ExpandoColumnConstants.INTEGER) ||
+			(columnType == ExpandoColumnConstants.INTEGER_ARRAY) ||
+			(columnType == ExpandoColumnConstants.LONG) ||
+			(columnType == ExpandoColumnConstants.LONG_ARRAY) ||
+			(columnType == ExpandoColumnConstants.SHORT) ||
+			(columnType == ExpandoColumnConstants.SHORT_ARRAY)) {
+
+			sb.append("_Number_sortable");
+		}
 
 		return sb.toString();
 	}

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -40,8 +41,6 @@ import com.liferay.portlet.expando.model.impl.ExpandoValueImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.commons.lang.ArrayUtils;
 
 /**
  * @author Raymond Augé
@@ -96,6 +95,8 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 		String fieldName = encodeFieldName(expandoColumn.getName(), indexType);
 
+		String indexedFieldName = encodeIndexedFieldName(expandoColumn);
+
 		ExpandoValue expandoValue = new ExpandoValueImpl();
 
 		expandoValue.setColumnId(expandoColumn.getColumnId());
@@ -130,29 +131,59 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 			document.addDate(fieldName, expandoValue.getDate());
 		}
 		else if (type == ExpandoColumnConstants.DOUBLE) {
-			document.addNumberSortable(fieldName, expandoValue.getDouble());
+			Field field = new Field(
+				indexedFieldName, String.valueOf(expandoValue.getDouble()));
+
+			field.setNumeric(true);
+			field.setNumericClass(Double.class);
+
+			document.add(field);
+
+			document.addKeyword(fieldName, expandoValue.getDouble());
 		}
 		else if (type == ExpandoColumnConstants.DOUBLE_ARRAY) {
 			if (!defaultValue) {
-				document.addNumberSortable(
-					fieldName,
-					ArrayUtils.toObject(expandoValue.getDoubleArray()));
+				Field field = new Field(
+					indexedFieldName,
+					ArrayUtil.toStringArray(expandoValue.getDoubleArray()));
+
+				field.setNumeric(true);
+				field.setNumericClass(Double.class);
+
+				document.add(field);
+
+				document.addKeyword(fieldName, expandoValue.getDoubleArray());
 			}
 			else {
-				document.addNumberSortable(fieldName, new Double[0]);
+				document.addKeyword(fieldName, new double[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.FLOAT) {
-			document.addNumberSortable(fieldName, expandoValue.getFloat());
+			Field field = new Field(
+				indexedFieldName, String.valueOf(expandoValue.getFloat()));
+
+			field.setNumeric(true);
+			field.setNumericClass(Float.class);
+
+			document.add(field);
+
+			document.addKeyword(fieldName, expandoValue.getFloat());
 		}
 		else if (type == ExpandoColumnConstants.FLOAT_ARRAY) {
 			if (!defaultValue) {
-				document.addNumberSortable(
-					fieldName,
-					ArrayUtils.toObject(expandoValue.getFloatArray()));
+				Field field = new Field(
+					indexedFieldName,
+					ArrayUtil.toStringArray(expandoValue.getFloatArray()));
+
+				field.setNumeric(true);
+				field.setNumericClass(Float.class);
+
+				document.add(field);
+
+				document.addKeyword(fieldName, expandoValue.getFloatArray());
 			}
 			else {
-				document.addNumberSortable(fieldName, new Float[0]);
+				document.addKeyword(fieldName, new float[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.GEOLOCATION) {
@@ -165,65 +196,122 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 				fieldName.concat("_geolocation"), latitude, longitude);
 		}
 		else if (type == ExpandoColumnConstants.INTEGER) {
-			document.addNumberSortable(fieldName, expandoValue.getInteger());
+			Field field = new Field(
+				indexedFieldName, String.valueOf(expandoValue.getInteger()));
+
+			field.setNumeric(true);
+			field.setNumericClass(Integer.class);
+
+			document.add(field);
+
+			document.addKeyword(fieldName, expandoValue.getInteger());
 		}
 		else if (type == ExpandoColumnConstants.INTEGER_ARRAY) {
 			if (!defaultValue) {
-				document.addNumberSortable(
-					fieldName,
-					ArrayUtils.toObject(expandoValue.getIntegerArray()));
+				Field field = new Field(
+					indexedFieldName,
+					ArrayUtil.toStringArray(expandoValue.getIntegerArray()));
+
+				field.setNumeric(true);
+				field.setNumericClass(Float.class);
+
+				document.add(field);
+
+				document.addKeyword(fieldName, expandoValue.getIntegerArray());
 			}
 			else {
-				document.addNumberSortable(fieldName, new Integer[0]);
+				document.addKeyword(fieldName, new int[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.LONG) {
-			document.addNumberSortable(fieldName, expandoValue.getLong());
+			Field field = new Field(
+				indexedFieldName, String.valueOf(expandoValue.getLong()));
+
+			field.setNumeric(true);
+			field.setNumericClass(Long.class);
+
+			document.add(field);
+
+			document.addKeyword(fieldName, expandoValue.getLong());
 		}
 		else if (type == ExpandoColumnConstants.LONG_ARRAY) {
 			if (!defaultValue) {
-				document.addNumberSortable(
-					fieldName,
-					ArrayUtil.toLongArray(expandoValue.getLongArray()));
+				Field field = new Field(
+					indexedFieldName,
+					ArrayUtil.toStringArray(expandoValue.getLongArray()));
+
+				field.setNumeric(true);
+				field.setNumericClass(Long.class);
+
+				document.add(field);
+
+				document.addKeyword(fieldName, expandoValue.getLongArray());
 			}
 			else {
-				document.addNumberSortable(fieldName, new Long[0]);
+				document.addKeyword(fieldName, new long[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.NUMBER) {
 			Number number = expandoValue.getNumber();
 
-			document.addNumberSortable(fieldName, number.longValue());
+			Field field = new Field(
+				indexedFieldName, String.valueOf(number.longValue()));
+
+			field.setNumeric(true);
+			field.setNumericClass(Long.class);
+
+			document.add(field);
+
+			document.addKeyword(
+				fieldName, String.valueOf(expandoValue.getNumber()));
 		}
 		else if (type == ExpandoColumnConstants.NUMBER_ARRAY) {
 			if (!defaultValue) {
-				document.addNumberSortable(
+				String[] stringValues = ArrayUtil.toStringArray(
+					expandoValue.getNumberArray());
+
+				Field field = new Field(
+					indexedFieldName, String.valueOf(stringValues));
+
+				field.setNumeric(true);
+				field.setNumericClass(Long.class);
+
+				document.add(field);
+
+				document.addKeyword(
 					fieldName,
-					ArrayUtil.toLongArray(expandoValue.getNumberArray()));
+					ArrayUtil.toStringArray(expandoValue.getNumberArray()));
 			}
 			else {
-				document.addNumberSortable(fieldName, new Long[0]);
+				document.addKeyword(fieldName, new long[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.SHORT) {
-			document.addNumberSortable(
-				fieldName, Integer.valueOf(expandoValue.getShort()));
+			Field field = new Field(
+				indexedFieldName, String.valueOf(expandoValue.getShort()));
+
+			field.setNumeric(true);
+			field.setNumericClass(Short.class);
+
+			document.add(field);
+
+			document.addKeyword(fieldName, expandoValue.getShort());
 		}
 		else if (type == ExpandoColumnConstants.SHORT_ARRAY) {
 			if (!defaultValue) {
-				Short[] shortArray = ArrayUtils.toObject(
-					expandoValue.getShortArray());
+				Field field = new Field(
+					indexedFieldName,
+					ArrayUtil.toStringArray(expandoValue.getShortArray()));
 
-				Integer[] integerArray = new Integer[shortArray.length];
+				field.setNumeric(true);
+				field.setNumericClass(Short.class);
 
-				for (int i = 0; i < integerArray.length; i++) {
-					integerArray[i] = Integer.valueOf(shortArray[i]);
-				}
+				document.add(field);
 
-				document.addNumberSortable(fieldName, integerArray);
+				document.addKeyword(fieldName, expandoValue.getShortArray());
 			}
 			else {
-				document.addNumberSortable(fieldName, new Integer[0]);
+				document.addKeyword(fieldName, new short[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.STRING) {

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -41,6 +41,8 @@ import com.liferay.portlet.expando.model.impl.ExpandoValueImpl;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.ArrayUtils;
+
 /**
  * @author Raymond Augé
  */
@@ -130,15 +132,9 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 		}
 		else if (type == ExpandoColumnConstants.DOUBLE_ARRAY) {
 			if (!defaultValue) {
-				double[] doubleValues = expandoValue.getDoubleArray();
-
-				Double[] doubleArray = new Double[doubleValues.length];
-
-				for (int i = 0; i < doubleArray.length; i++) {
-					doubleArray[i] = new Double(doubleValues[i]);
-				}
-
-				document.addNumberSortable(fieldName, doubleArray);
+				document.addNumberSortable(
+					fieldName,
+					ArrayUtils.toObject(expandoValue.getDoubleArray()));
 			}
 			else {
 				document.addNumberSortable(fieldName, new Double[0]);
@@ -149,15 +145,9 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 		}
 		else if (type == ExpandoColumnConstants.FLOAT_ARRAY) {
 			if (!defaultValue) {
-				float[] floatValues = expandoValue.getFloatArray();
-
-				Float[] floatArray = new Float[floatValues.length];
-
-				for (int i = 0; i < floatArray.length; i++) {
-					floatArray[i] = new Float(floatValues[i]);
-				}
-
-				document.addNumberSortable(fieldName, floatArray);
+				document.addNumberSortable(
+					fieldName,
+					ArrayUtils.toObject(expandoValue.getFloatArray()));
 			}
 			else {
 				document.addNumberSortable(fieldName, new Float[0]);
@@ -177,18 +167,12 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 		}
 		else if (type == ExpandoColumnConstants.INTEGER_ARRAY) {
 			if (!defaultValue) {
-				int[] intergerValues = expandoValue.getIntegerArray();
-
-				Integer[] integerArray = new Integer[intergerValues.length];
-
-				for (int i = 0; i < integerArray.length; i++) {
-					integerArray[i] = new Integer(intergerValues[i]);
-				}
-
-				document.addNumberSortable(fieldName, integerArray);
+				document.addNumberSortable(
+					fieldName,
+					ArrayUtils.toObject(expandoValue.getIntegerArray()));
 			}
 			else {
-				document.addNumberSortable(fieldName, new Float[0]);
+				document.addNumberSortable(fieldName, new Integer[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.LONG) {
@@ -196,7 +180,8 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 		}
 		else if (type == ExpandoColumnConstants.LONG_ARRAY) {
 			if (!defaultValue) {
-				document.addNumberSortable(fieldName,
+				document.addNumberSortable(
+					fieldName,
 					ArrayUtil.toLongArray(expandoValue.getLongArray()));
 			}
 			else {
@@ -204,8 +189,9 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 			}
 		}
 		else if (type == ExpandoColumnConstants.NUMBER) {
-			document.addNumberSortable(
-				fieldName, expandoValue.getNumber().longValue());
+			Number number = expandoValue.getNumber();
+
+			document.addNumberSortable(fieldName, number.longValue());
 		}
 		else if (type == ExpandoColumnConstants.NUMBER_ARRAY) {
 			if (!defaultValue) {
@@ -218,23 +204,24 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 			}
 		}
 		else if (type == ExpandoColumnConstants.SHORT) {
-			document.addNumberSortable(fieldName,
-				new Long(expandoValue.getShort()));
+			document.addNumberSortable(
+				fieldName, Integer.valueOf(expandoValue.getShort()));
 		}
 		else if (type == ExpandoColumnConstants.SHORT_ARRAY) {
 			if (!defaultValue) {
-				short[] shortValues = expandoValue.getShortArray();
+				Short[] shortArray = ArrayUtils.toObject(
+					expandoValue.getShortArray());
 
-				Long[] longArray = new Long[shortValues.length];
+				Integer[] integerArray = new Integer[shortArray.length];
 
-				for (int i = 0; i < longArray.length; i++) {
-					longArray[i] = new Long(shortValues[i]);
+				for (int i = 0; i < integerArray.length; i++) {
+					integerArray[i] = Integer.valueOf(shortArray[i]);
 				}
 
-				document.addNumberSortable(fieldName, longArray);
+				document.addNumberSortable(fieldName, integerArray);
 			}
 			else {
-				document.addNumberSortable(fieldName, new Long[0]);
+				document.addNumberSortable(fieldName, new Integer[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.STRING) {

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -63,11 +63,11 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 	@Override
 	public String encodeFieldName(String columnName, int indexType) {
-		return _encodeIndexedFieldName(columnName, 0, indexType);
+		return _encodeSortableFieldName(columnName, 0, indexType);
 	}
 
 	@Override
-	public String encodeIndexedFieldName(ExpandoColumn expandoColumn) {
+	public String encodeSortableFieldName(ExpandoColumn expandoColumn) {
 		UnicodeProperties unicodeProperties =
 			expandoColumn.getTypeSettingsProperties();
 
@@ -78,7 +78,7 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 			return StringPool.BLANK;
 		}
 
-		return _encodeIndexedFieldName(
+		return _encodeSortableFieldName(
 			expandoColumn.getName(), expandoColumn.getType(), indexType);
 	}
 
@@ -95,7 +95,7 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 		String fieldName = encodeFieldName(expandoColumn.getName(), indexType);
 
-		String indexedFieldName = encodeIndexedFieldName(expandoColumn);
+		String indexedFieldName = encodeSortableFieldName(expandoColumn);
 
 		ExpandoValue expandoValue = new ExpandoValueImpl();
 
@@ -406,7 +406,7 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 	protected static final String FIELD_NAMESPACE = "expando";
 
-	private String _encodeIndexedFieldName(
+	private String _encodeSortableFieldName(
 		String columnName, int columnType, int indexType) {
 
 		StringBundler sb = new StringBundler(7);

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -126,25 +126,41 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 			document.addDate(fieldName, expandoValue.getDate());
 		}
 		else if (type == ExpandoColumnConstants.DOUBLE) {
-			document.addKeyword(fieldName, expandoValue.getDouble());
+			document.addNumberSortable(fieldName, expandoValue.getDouble());
 		}
 		else if (type == ExpandoColumnConstants.DOUBLE_ARRAY) {
 			if (!defaultValue) {
-				document.addKeyword(fieldName, expandoValue.getDoubleArray());
+				double[] doubleValues = expandoValue.getDoubleArray();
+
+				Double[] doubleArray = new Double[doubleValues.length];
+
+				for (int i = 0; i < doubleArray.length; i++) {
+					doubleArray[i] = new Double(doubleValues[i]);
+				}
+
+				document.addNumberSortable(fieldName, doubleArray);
 			}
 			else {
-				document.addKeyword(fieldName, new double[0]);
+				document.addNumberSortable(fieldName, new Double[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.FLOAT) {
-			document.addKeyword(fieldName, expandoValue.getFloat());
+			document.addNumberSortable(fieldName, expandoValue.getFloat());
 		}
 		else if (type == ExpandoColumnConstants.FLOAT_ARRAY) {
 			if (!defaultValue) {
-				document.addKeyword(fieldName, expandoValue.getFloatArray());
+				float[] floatValues = expandoValue.getFloatArray();
+
+				Float[] floatArray = new Float[floatValues.length];
+
+				for (int i = 0; i < floatArray.length; i++) {
+					floatArray[i] = new Float(floatValues[i]);
+				}
+
+				document.addNumberSortable(fieldName, floatArray);
 			}
 			else {
-				document.addKeyword(fieldName, new float[0]);
+				document.addNumberSortable(fieldName, new Float[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.GEOLOCATION) {
@@ -157,50 +173,68 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 				fieldName.concat("_geolocation"), latitude, longitude);
 		}
 		else if (type == ExpandoColumnConstants.INTEGER) {
-			document.addKeyword(fieldName, expandoValue.getInteger());
+			document.addNumberSortable(fieldName, expandoValue.getInteger());
 		}
 		else if (type == ExpandoColumnConstants.INTEGER_ARRAY) {
 			if (!defaultValue) {
-				document.addKeyword(fieldName, expandoValue.getIntegerArray());
+				int[] intergerValues = expandoValue.getIntegerArray();
+
+				Integer[] integerArray = new Integer[intergerValues.length];
+
+				for (int i = 0; i < integerArray.length; i++) {
+					integerArray[i] = new Integer(intergerValues[i]);
+				}
+
+				document.addNumberSortable(fieldName, integerArray);
 			}
 			else {
-				document.addKeyword(fieldName, new int[0]);
+				document.addNumberSortable(fieldName, new Float[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.LONG) {
-			document.addKeyword(fieldName, expandoValue.getLong());
+			document.addNumberSortable(fieldName, expandoValue.getLong());
 		}
 		else if (type == ExpandoColumnConstants.LONG_ARRAY) {
 			if (!defaultValue) {
-				document.addKeyword(fieldName, expandoValue.getLongArray());
+				document.addNumberSortable(fieldName,
+					ArrayUtil.toLongArray(expandoValue.getLongArray()));
 			}
 			else {
-				document.addKeyword(fieldName, new long[0]);
+				document.addNumberSortable(fieldName, new Long[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.NUMBER) {
-			document.addKeyword(
-				fieldName, String.valueOf(expandoValue.getNumber()));
+			document.addNumberSortable(
+				fieldName, expandoValue.getNumber().longValue());
 		}
 		else if (type == ExpandoColumnConstants.NUMBER_ARRAY) {
 			if (!defaultValue) {
-				document.addKeyword(
+				document.addNumberSortable(
 					fieldName,
-					ArrayUtil.toStringArray(expandoValue.getNumberArray()));
+					ArrayUtil.toLongArray(expandoValue.getNumberArray()));
 			}
 			else {
-				document.addKeyword(fieldName, new long[0]);
+				document.addNumberSortable(fieldName, new Long[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.SHORT) {
-			document.addKeyword(fieldName, expandoValue.getShort());
+			document.addNumberSortable(fieldName,
+				new Long(expandoValue.getShort()));
 		}
 		else if (type == ExpandoColumnConstants.SHORT_ARRAY) {
 			if (!defaultValue) {
-				document.addKeyword(fieldName, expandoValue.getShortArray());
+				short[] shortValues = expandoValue.getShortArray();
+
+				Long[] longArray = new Long[shortValues.length];
+
+				for (int i = 0; i < longArray.length; i++) {
+					longArray[i] = new Long(shortValues[i]);
+				}
+
+				document.addNumberSortable(fieldName, longArray);
 			}
 			else {
-				document.addKeyword(fieldName, new short[0]);
+				document.addNumberSortable(fieldName, new Long[0]);
 			}
 		}
 		else if (type == ExpandoColumnConstants.STRING) {

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -64,42 +64,23 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 	@Override
 	public String encodeFieldName(String columnName, int indexType) {
-		return encodeIndexedFieldName(columnName, 0, indexType);
+		return _encodeIndexedFieldName(columnName, 0, indexType);
 	}
 
 	@Override
-	public String encodeIndexedFieldName(
-		String columnName, int columnType, int indexType) {
+	public String encodeIndexedFieldName(ExpandoColumn expandoColumn) {
+		UnicodeProperties unicodeProperties =
+			expandoColumn.getTypeSettingsProperties();
 
-		StringBundler sb = new StringBundler(7);
+		int indexType = GetterUtil.getInteger(
+			unicodeProperties.get(ExpandoColumnConstants.INDEX_TYPE));
 
-		sb.append(FIELD_NAMESPACE);
-		sb.append(StringPool.DOUBLE_UNDERLINE);
-
-		if (indexType == ExpandoColumnConstants.INDEX_TYPE_KEYWORD) {
-			sb.append("keyword__");
+		if (indexType == ExpandoColumnConstants.INDEX_TYPE_NONE) {
+			return StringPool.BLANK;
 		}
 
-		sb.append(
-			StringUtil.toLowerCase(ExpandoTableConstants.DEFAULT_TABLE_NAME));
-		sb.append(StringPool.DOUBLE_UNDERLINE);
-		sb.append(columnName);
-
-		if ((columnType == ExpandoColumnConstants.DOUBLE) ||
-			(columnType == ExpandoColumnConstants.DOUBLE_ARRAY) ||
-			(columnType == ExpandoColumnConstants.FLOAT) ||
-			(columnType == ExpandoColumnConstants.FLOAT_ARRAY) ||
-			(columnType == ExpandoColumnConstants.INTEGER) ||
-			(columnType == ExpandoColumnConstants.INTEGER_ARRAY) ||
-			(columnType == ExpandoColumnConstants.LONG) ||
-			(columnType == ExpandoColumnConstants.LONG_ARRAY) ||
-			(columnType == ExpandoColumnConstants.SHORT) ||
-			(columnType == ExpandoColumnConstants.SHORT_ARRAY)) {
-
-			sb.append("_Number_sortable");
-		}
-
-		return sb.toString();
+		return _encodeIndexedFieldName(
+			expandoColumn.getName(), expandoColumn.getType(), indexType);
 	}
 
 	protected void addAttribute(
@@ -336,6 +317,40 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 	}
 
 	protected static final String FIELD_NAMESPACE = "expando";
+
+	private String _encodeIndexedFieldName(
+		String columnName, int columnType, int indexType) {
+
+		StringBundler sb = new StringBundler(7);
+
+		sb.append(FIELD_NAMESPACE);
+		sb.append(StringPool.DOUBLE_UNDERLINE);
+
+		if (indexType == ExpandoColumnConstants.INDEX_TYPE_KEYWORD) {
+			sb.append("keyword__");
+		}
+
+		sb.append(
+			StringUtil.toLowerCase(ExpandoTableConstants.DEFAULT_TABLE_NAME));
+		sb.append(StringPool.DOUBLE_UNDERLINE);
+		sb.append(columnName);
+
+		if ((columnType == ExpandoColumnConstants.DOUBLE) ||
+			(columnType == ExpandoColumnConstants.DOUBLE_ARRAY) ||
+			(columnType == ExpandoColumnConstants.FLOAT) ||
+			(columnType == ExpandoColumnConstants.FLOAT_ARRAY) ||
+			(columnType == ExpandoColumnConstants.INTEGER) ||
+			(columnType == ExpandoColumnConstants.INTEGER_ARRAY) ||
+			(columnType == ExpandoColumnConstants.LONG) ||
+			(columnType == ExpandoColumnConstants.LONG_ARRAY) ||
+			(columnType == ExpandoColumnConstants.SHORT) ||
+			(columnType == ExpandoColumnConstants.SHORT_ARRAY)) {
+
+			sb.append("_Number_sortable");
+		}
+
+		return sb.toString();
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExpandoBridgeIndexerImpl.class);

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -64,11 +64,11 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 
 	@Override
 	public String encodeFieldName(String columnName, int indexType) {
-		return encodeFieldName(columnName, 0, indexType);
+		return encodeIndexedFieldName(columnName, 0, indexType);
 	}
 
 	@Override
-	public String encodeFieldName(
+	public String encodeIndexedFieldName(
 		String columnName, int columnType, int indexType) {
 
 		StringBundler sb = new StringBundler(7);

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoBridgeIndexerImpl.java
@@ -336,17 +336,29 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 		sb.append(columnName);
 
 		if ((columnType == ExpandoColumnConstants.DOUBLE) ||
-			(columnType == ExpandoColumnConstants.DOUBLE_ARRAY) ||
-			(columnType == ExpandoColumnConstants.FLOAT) ||
-			(columnType == ExpandoColumnConstants.FLOAT_ARRAY) ||
-			(columnType == ExpandoColumnConstants.INTEGER) ||
-			(columnType == ExpandoColumnConstants.INTEGER_ARRAY) ||
-			(columnType == ExpandoColumnConstants.LONG) ||
-			(columnType == ExpandoColumnConstants.LONG_ARRAY) ||
-			(columnType == ExpandoColumnConstants.SHORT) ||
-			(columnType == ExpandoColumnConstants.SHORT_ARRAY)) {
+			(columnType == ExpandoColumnConstants.DOUBLE_ARRAY)) {
 
-			sb.append("_Number_sortable");
+			sb.append("_Double_sortable");
+		}
+		else if ((columnType == ExpandoColumnConstants.FLOAT) ||
+				 (columnType == ExpandoColumnConstants.FLOAT_ARRAY)) {
+
+			sb.append("_Float_sortable");
+		}
+		else if ((columnType == ExpandoColumnConstants.INTEGER) ||
+				 (columnType == ExpandoColumnConstants.INTEGER_ARRAY)) {
+
+			sb.append("_Integer_sortable");
+		}
+		else if ((columnType == ExpandoColumnConstants.LONG) ||
+				 (columnType == ExpandoColumnConstants.LONG_ARRAY)) {
+
+			sb.append("_Long_sortable");
+		}
+		else if ((columnType == ExpandoColumnConstants.SHORT) ||
+				 (columnType == ExpandoColumnConstants.SHORT_ARRAY)) {
+
+			sb.append("_Short_sortable");
 		}
 
 		return sb.toString();

--- a/portal-impl/src/com/liferay/portlet/expando/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/expando/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
@@ -30,6 +30,6 @@ public interface ExpandoBridgeIndexer {
 
 	public String encodeFieldName(String columnName, int indexType);
 
-	public String encodeIndexedFieldName(ExpandoColumn expandoColumn);
+	public String encodeSortableFieldName(ExpandoColumn expandoColumn);
 
 }

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
@@ -15,6 +15,7 @@
 package com.liferay.expando.kernel.util;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.portal.kernel.search.Document;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -29,7 +30,6 @@ public interface ExpandoBridgeIndexer {
 
 	public String encodeFieldName(String columnName, int indexType);
 
-	public String encodeIndexedFieldName(
-		String columnName, int columnType, int indexType);
+	public String encodeIndexedFieldName(ExpandoColumn expandoColumn);
 
 }

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
@@ -29,4 +29,7 @@ public interface ExpandoBridgeIndexer {
 
 	public String encodeFieldName(String columnName, int indexType);
 
+	public String encodeFieldName(
+		String columnName, int columnType, int indexType);
+
 }

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexer.java
@@ -29,7 +29,7 @@ public interface ExpandoBridgeIndexer {
 
 	public String encodeFieldName(String columnName, int indexType);
 
-	public String encodeFieldName(
+	public String encodeIndexedFieldName(
 		String columnName, int columnType, int indexType);
 
 }

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
@@ -32,10 +32,10 @@ public class ExpandoBridgeIndexerUtil {
 		return _expandoBridgeIndexer.encodeFieldName(columnName, indexType);
 	}
 
-	public static String encodeFieldName(
+	public static String encodeIndexedFieldName(
 		String columnName, int columnType, int indexType) {
 
-		return _expandoBridgeIndexer.encodeFieldName(
+		return _expandoBridgeIndexer.encodeIndexedFieldName(
 			columnName, columnType, indexType);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
@@ -32,6 +32,13 @@ public class ExpandoBridgeIndexerUtil {
 		return _expandoBridgeIndexer.encodeFieldName(columnName, indexType);
 	}
 
+	public static String encodeFieldName(
+		String columnName, int columnType, int indexType) {
+
+		return _expandoBridgeIndexer.encodeFieldName(
+			columnName, columnType, indexType);
+	}
+
 	public static ExpandoBridgeIndexer getExpandoBridgeIndexer() {
 		return _expandoBridgeIndexer;
 	}

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
@@ -33,8 +33,8 @@ public class ExpandoBridgeIndexerUtil {
 		return _expandoBridgeIndexer.encodeFieldName(columnName, indexType);
 	}
 
-	public static String encodeIndexedFieldName(ExpandoColumn expandoColumn) {
-		return _expandoBridgeIndexer.encodeIndexedFieldName(expandoColumn);
+	public static String encodeSortableFieldName(ExpandoColumn expandoColumn) {
+		return _expandoBridgeIndexer.encodeSortableFieldName(expandoColumn);
 	}
 
 	public static ExpandoBridgeIndexer getExpandoBridgeIndexer() {

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoBridgeIndexerUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.expando.kernel.util;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.portal.kernel.search.Document;
 
 /**
@@ -32,11 +33,8 @@ public class ExpandoBridgeIndexerUtil {
 		return _expandoBridgeIndexer.encodeFieldName(columnName, indexType);
 	}
 
-	public static String encodeIndexedFieldName(
-		String columnName, int columnType, int indexType) {
-
-		return _expandoBridgeIndexer.encodeIndexedFieldName(
-			columnName, columnType, indexType);
+	public static String encodeIndexedFieldName(ExpandoColumn expandoColumn) {
+		return _expandoBridgeIndexer.encodeIndexedFieldName(expandoColumn);
 	}
 
 	public static ExpandoBridgeIndexer getExpandoBridgeIndexer() {

--- a/portal-kernel/src/com/liferay/expando/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/portal-kernel/src/com/liferay/expando/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.0.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-149028

Hi @BryanEngler,

Test is not finished, but could you take a look. I believe we need to index 2 fields for each of the numeric types, because if we simply change the string type to keyword, the normal way we search against the expando field breaks the query, but the segments-service needs the numeric type.

Also note ExpandoBridgeIndexerImpl.java ln 77-79, I'm not sure how we should fail in this case.
